### PR TITLE
Fix SocketPlugin DNS lookup scope

### DIFF
--- a/plugins/SocketPlugin.js
+++ b/plugins/SocketPlugin.js
@@ -1071,6 +1071,8 @@ function SocketPlugin() {
     primitiveResolverStartNameLookup: function(argCount) {
       if (argCount !== 1) return false;
 
+      var plugin = this;
+
       // Start new lookup, ignoring if one is in progress
       var lookup = this.lastLookup = this.interpreterProxy.stackValue(0).bytesAsString();
 


### PR DESCRIPTION
## Summary
- ensure `primitiveResolverStartNameLookup` closes over the plugin instance so tunnel fallback callbacks can reference it without throwing `ReferenceError`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e055842fe8832a95d42c496c15b72e