### PR TITLE
Implement suspend-and-backup process primitive and add tests

### DIFF
--- a/tests/resources/tests.st
+++ b/tests/resources/tests.st
@@ -15,5 +15,56 @@ SqueakJSLargeIntegerPrimitiveTest >> testDigitComparePrimitive
     self assert: (high digitCompare: low) = 1.
     self assert: (low digitCompare: high) = -1.
 
+Object subclass: #SqueakJSSuspendAndBackupPCTestHelper
+    instanceVariableNames: 'shouldSuspend resumeValue'
+    classVariableNames: ''
+    package: 'SqueakJSTesting'.
+
+SqueakJSSuspendAndBackupPCTestHelper >> initialize
+    super initialize.
+    shouldSuspend := true.
+    resumeValue := nil.
+
+SqueakJSSuspendAndBackupPCTestHelper >> shouldSuspend
+    ^ shouldSuspend
+
+SqueakJSSuspendAndBackupPCTestHelper >> resumeValue
+    ^ resumeValue
+
+SqueakJSSuspendAndBackupPCTestHelper >> waitForSuspend
+    shouldSuspend ifTrue: [
+        shouldSuspend := false.
+        Processor activeProcess suspendAndBackupPC ].
+    resumeValue := #resumed.
+    ^ resumeValue
+
+TestCase subclass: #SqueakJSSuspendAndBackupPCTest
+    instanceVariableNames: ''
+    classVariableNames: ''
+    package: 'SqueakJSTesting'.
+
+SqueakJSSuspendAndBackupPCTest >> testSuspendAndBackupPC
+    | helper process context method expectedPC |
+    helper := SqueakJSSuspendAndBackupPCTestHelper new.
+    process := [ helper waitForSuspend ] newProcess.
+    process priority: Processor activePriority + 1.
+    process resume.
+    Processor yield.
+    context := process suspendedContext.
+    self assert: helper shouldSuspend not.
+    self assert: context method selector = #waitForSuspend.
+    self assert: context top = process.
+    method := context method.
+    expectedPC := nil.
+    method symbolic linesDo: [:line |
+        (line includesSubstring: 'suspendAndBackupPC') ifTrue: [
+            expectedPC := (line upTo: $<) withBlanksTrimmed asNumber ]].
+    self assert: expectedPC notNil.
+    self assert: context pc = expectedPC.
+    process resume.
+    Processor yield.
+    self assert: helper resumeValue = #resumed.
+    process terminate.
+
 SqueakJSTesting test: 'tests.ston'.
 Smalltalk quitPrimitive

--- a/tests/resources/tests.ston
+++ b/tests/resources/tests.ston
@@ -8,10 +8,11 @@ SmalltalkCISpec {
         #LinkedListTest, #OrderedCollectionTest,
         #OrderedDictionaryTest, #SequenceableCollectionTest,
         #SortedCollectionTest,
-        #StackTest,
-        #CharacterTest, #SymbolTest,
-        #BagTest, #SetTest,
-        #SqueakJSLargeIntegerPrimitiveTest
+      #StackTest,
+      #CharacterTest, #SymbolTest,
+      #BagTest, #SetTest,
+        #SqueakJSLargeIntegerPrimitiveTest,
+        #SqueakJSSuspendAndBackupPCTest
       ]
     }
   }


### PR DESCRIPTION
## Summary
- implement primitiveSuspendAndBackupPC to back up the waiting context and reuse interpreter helpers
- set the VM parameter flag indicating suspend-and-backup support and expose a regression test with helper classes

## Testing
- npm --prefix tests test *(fails: Chrome binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e124c7f6ac832a82f885e9f9f3f49e