### PR TITLE
Remove misspelled alpha numeric selector

### DIFF
--- a/vm.interpreter.js
+++ b/vm.interpreter.js
@@ -962,7 +962,12 @@ Object.subclass('Squeak.Interpreter',
         return this.characterFromCodePoint(receiver);
     },
     shouldCoerceSmallIntegerSelector: function(selectorName) {
-        return selectorName === "isSeparator";
+        switch (selectorName) {
+            case "isSeparator":
+            case "isAlphaNumeric":
+                return true;
+        }
+        return false;
     },
     characterFromCodePoint: function(codePoint) {
         if (codePoint == null) return null;


### PR DESCRIPTION
## Summary
- remove the unnecessary misspelled `isAlphaNumberic` selector entry in the SmallInteger coercion logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e129f2a138832a8c78913b695368ed