### PR TITLE
Add missing browser plugin and clock mask primitives

### DIFF
--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -2332,6 +2332,10 @@ Object.subclass('Squeak.Primitives',
     primitiveSetGCBiasToGrowGCLimit: function(argCount) {
         return this.fakePrimitive(".primitiveSetGCBiasToGrowGCLimit", 0, argCount);
     },
+    primitivePluginBrowserReady: function(argCount) {
+        // Older images check whether the browser plugin is available. Always true in SqueakJS.
+        return this.popNandPushIfOK(argCount + 1, this.vm.trueObj);
+    },
 },
 'time', {
     primitiveRelinquishProcessorForMicroseconds: function(argCount) {
@@ -2378,6 +2382,9 @@ Object.subclass('Squeak.Primitives',
         if (!this.microsecondClockLocalState)
             this.microsecondClockLocalState = {epoch: Squeak.Epoch, millis: 0, micros: 0};
         return this.microsecondClock(this.microsecondClockLocalState);
+    },
+    primitiveMillisecondClockMask: function(argCount) {
+        return this.popNandPushIntIfOK(argCount + 1, Squeak.MillisecondClockMask);
     },
     primitiveUtcWithOffset: function(argCount) {
         var d = new Date();


### PR DESCRIPTION
## Summary
- implement primitivePluginBrowserReady to always report plugin readiness in the browser runtime
- add primitiveMillisecondClockMask to return the VM's millisecond clock mask value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e131798bd4832aa80cef5f3f161fad