### PR TITLE
Fix stream primitive coercion for String subclasses

### DIFF
--- a/tests/vm-coercion/README.md
+++ b/tests/vm-coercion/README.md
@@ -1,11 +1,15 @@
-VM coercion conformance: manual verification
+VM coercion conformance
 
 Scope
 - Verify stream and indexed coercion semantics after VM changes:
   - String and subclasses: read Characters; writes require Character.
   - ByteString: read SmallInteger 0..255 unless convertChars; writes accept Character or 0..255 SmallInteger, with range enforced.
 
-How to run manually
+Automated regression
+- A lightweight Node harness exercises `ReadStream`/`WriteStream` semantics for textual `ByteString` and `WideString` receivers.
+- Run with `node tests/vm-coercion/stream-coercion.test.js` from the repository root.
+
+Manual verification
 1) Start the demo server:
    - npm install
    - npm start
@@ -21,6 +25,3 @@ How to run manually
    - No “MessageNotUnderstood: ByteString>>charCode”
    - No “Improper store into indexable object”
    - [VMDBG] prim65/prim66/objectAt/objectAtPut logs show Character for String and subclasses. ByteString reads show SmallInteger unless convertChars path is used; nextPut: into String requires Character; nextPut: into ByteString accepts Character or integer 0..255 and rejects out of range.
-
-Notes
-- This repository does not currently include a headless unit-test harness that constructs Squeak objects and invokes primitives without fully loading an image. If desired, a future follow-up can add a Node-based harness around dist/squeak_headless_bundle.js to fabricate String/ByteString instances and drive primitives 65/66 and objectAt/objectAtPut directly.

--- a/tests/vm-coercion/stream-coercion.test.js
+++ b/tests/vm-coercion/stream-coercion.test.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+
+global.self = global;
+
+require("../../globals.js");
+require("../../vm.js");
+require("../../vm.object.js");
+require("../../vm.interpreter.proxy.js");
+require("../../vm.primitives.js");
+
+const nilObj = new Squeak.Object();
+nilObj.isNil = true;
+nilObj.pointers = [];
+nilObj._format = 0;
+nilObj.sqClass = null;
+
+function makeClass(superclass) {
+    const cls = new Squeak.Object();
+    cls.isNil = false;
+    cls.pointers = [];
+    cls.pointers[Squeak.Class_superclass] = superclass || nilObj;
+    cls.pointers[Squeak.Class_format] = 0;
+    cls._format = 0;
+    cls.classInstSize = function() { return 0; };
+    return cls;
+}
+
+const objectClass = makeClass(nilObj);
+const stringClass = makeClass(objectClass);
+const byteStringClass = makeClass(stringClass);
+const wideStringClass = makeClass(stringClass);
+const characterClass = makeClass(objectClass);
+
+const specialObjects = [];
+specialObjects[Squeak.splOb_ClassString] = stringClass;
+specialObjects[Squeak.splOb_ClassCharacter] = characterClass;
+specialObjects[Squeak.splOb_CharacterTable] = { pointers: [] };
+
+const vm = {
+    stack: [],
+    image: {
+        hasClosures: true,
+        isSpur: false,
+        bytesLeft: () => Number.MAX_SAFE_INTEGER,
+    },
+    specialObjects: specialObjects,
+    nilObj: nilObj,
+    trueObj: { isTrue: true },
+    falseObj: { isFalse: true },
+    verifyAtSelector: null,
+    verifyAtClass: null,
+    specialSelectors: [],
+    stackValue(n) {
+        return this.stack[this.stack.length - 1 - n];
+    },
+    top() {
+        return this.stack[this.stack.length - 1];
+    },
+    push(value) {
+        this.stack.push(value);
+    },
+    pop() {
+        return this.stack.pop();
+    },
+    popNandPush(nToPop, value) {
+        this.stack.splice(this.stack.length - nToPop, nToPop, value);
+    },
+    canBeSmallInt(value) {
+        return typeof value === "number" && value >= Squeak.MinSmallInt && value <= Squeak.MaxSmallInt;
+    },
+    instantiateClass(cls, indexableSize) {
+        const inst = new Squeak.Object();
+        inst.sqClass = cls;
+        inst.isNil = false;
+        inst._format = 0;
+        inst.pointers = new Array(indexableSize);
+        for (let i = 0; i < indexableSize; i++) inst.pointers[i] = this.nilObj;
+        return inst;
+    },
+    isContext() {
+        return false;
+    },
+};
+
+const primitives = new Squeak.Primitives(vm, null);
+primitives.charFromInt = function(codePoint) {
+    return { isCharacter: true, codePoint: codePoint, sqClass: characterClass };
+};
+primitives.charToInt = function(character) {
+    return character.codePoint;
+};
+
+function makeByteString(bytes) {
+    const obj = new Squeak.Object();
+    obj.sqClass = byteStringClass;
+    obj.isNil = false;
+    obj._format = 8;
+    obj.bytes = new Uint8Array(bytes);
+    obj.pointers = [];
+    obj.hash = 1;
+    return obj;
+}
+
+function makeWideString(codePoints) {
+    const obj = new Squeak.Object();
+    obj.sqClass = wideStringClass;
+    obj.isNil = false;
+    obj._format = 6;
+    obj.words = new Uint32Array(codePoints);
+    obj.pointers = [];
+    obj.hash = 2;
+    return obj;
+}
+
+function makeStream(collection) {
+    const stream = new Squeak.Object();
+    stream.sqClass = objectClass;
+    stream.isNil = false;
+    stream._format = 0;
+    stream.pointers = [];
+    stream.pointers[Squeak.Stream_array] = collection;
+    stream.pointers[Squeak.Stream_position] = 0;
+    let limit = 0;
+    if (collection.isBytes && collection.isBytes()) limit = collection.bytes.length;
+    else if (collection.isWords && collection.isWords()) limit = collection.words.length;
+    else if (collection.pointers) limit = collection.pointers.length;
+    stream.pointers[Squeak.Stream_limit] = limit;
+    return stream;
+}
+
+function runPrimitive(index, argCount) {
+    primitives.success = true;
+    return primitives.doPrimitive(index, argCount);
+}
+
+(function testByteStringReadReturnsCharacter() {
+    const byteString = makeByteString([65, 66]);
+    const stream = makeStream(byteString);
+    vm.stack = [stream];
+    assert.strictEqual(runPrimitive(65, 0), true, "primitiveNext should succeed for ByteString");
+    const result = vm.stack[0];
+    assert.ok(result && result.isCharacter, "ByteString next should produce a Character");
+    assert.strictEqual(result.codePoint, 65, "Character code should match first byte");
+    assert.strictEqual(stream.pointers[Squeak.Stream_position], 1, "Stream position should advance by one");
+})();
+
+(function testByteStringWriteRequiresCharacter() {
+    const byteString = makeByteString([0, 0]);
+    const stream = makeStream(byteString);
+    const character = primitives.charFromInt(90);
+    vm.stack = [stream, character];
+    assert.strictEqual(runPrimitive(66, 1), true, "primitiveNextPut: should accept Character for ByteString");
+    assert.strictEqual(vm.stack[0], character, "nextPut: should answer the argument");
+    assert.strictEqual(byteString.bytes[0], 90, "ByteString should store the character code");
+    assert.strictEqual(stream.pointers[Squeak.Stream_position], 1, "Stream position should advance");
+
+    const rejected = makeStream(makeByteString([0]));
+    vm.stack = [rejected, 65];
+    assert.strictEqual(runPrimitive(66, 1), false, "primitiveNextPut: should reject SmallInteger for textual ByteString");
+    assert.strictEqual(rejected.pointers[Squeak.Stream_position], 0, "Position should not advance on failure");
+})();
+
+(function testWideStringReadAndWriteCharacters() {
+    const smile = 0x1F642;
+    const wideString = makeWideString([smile]);
+    const stream = makeStream(wideString);
+    vm.stack = [stream];
+    assert.strictEqual(runPrimitive(65, 0), true, "primitiveNext should succeed for WideString");
+    const result = vm.stack[0];
+    assert.ok(result && result.isCharacter, "WideString next should produce a Character");
+    assert.strictEqual(result.codePoint, smile, "WideString next should yield Unicode code point");
+    assert.strictEqual(stream.pointers[Squeak.Stream_position], 1, "WideString read should advance position");
+
+    const euro = 0x20AC;
+    const writable = makeWideString([0]);
+    const writeStream = makeStream(writable);
+    const euroChar = primitives.charFromInt(euro);
+    vm.stack = [writeStream, euroChar];
+    assert.strictEqual(runPrimitive(66, 1), true, "primitiveNextPut: should accept Character for WideString");
+    assert.strictEqual(writable.words[0], euro, "WideString should store full Unicode code point");
+    assert.strictEqual(writeStream.pointers[Squeak.Stream_position], 1, "WideString write should advance position");
+
+    const rejectWide = makeStream(makeWideString([0]));
+    vm.stack = [rejectWide, euro];
+    assert.strictEqual(runPrimitive(66, 1), false, "primitiveNextPut: should reject integers for WideString");
+    assert.strictEqual(rejectWide.pointers[Squeak.Stream_position], 0, "WideString position should remain when write rejected");
+})();
+
+console.log("Stream coercion tests passed.");

--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -216,19 +216,24 @@ Object.subclass('Squeak.Primitives',
                 if (pos >= lim) return false;
                 var index = pos + 1; // Smalltalk is 1-based
                 var value;
+                var isTextual = arr && this.isKindOf(arr, Squeak.splOb_ClassString);
                 if (arr.isPointers && arr.isPointers()) {
                     value = arr.pointers[index - 1];
                 } else if (arr.isWords && arr.isWords()) {
-                    value = this.pos32BitIntFor(arr.words[index - 1]);
+                    if (isTextual) {
+                        value = this.charFromInt(arr.words[index - 1] & 0x3FFFFFFF);
+                    } else {
+                        value = this.pos32BitIntFor(arr.words[index - 1]);
+                    }
                 } else if (arr.isBytes && arr.isBytes()) {
-                    if (this.isA(arr, Squeak.splOb_ClassString))
+                    if (isTextual)
                         value = this.charFromInt(arr.bytes[index - 1] & 0xFF);
                     else
                         value = arr.bytes[index - 1] & 0xFF;
                 } else {
                     this.vm.push(arr);
                     this.vm.push(index);
-                    value = this.objectAt(false, this.isA(arr, Squeak.splOb_ClassString), false);
+                    value = this.objectAt(false, isTextual, false);
                     if (!this.success) return false;
                     this.vm.pop(); // remove index
                     this.vm.pop(); // remove array
@@ -250,16 +255,24 @@ Object.subclass('Squeak.Primitives',
                 if (pos >= lim) return false;
                 var index = pos + 1;
                 if (this._vmdbgLog) this._vmdbgLog({site:"prim66",op:"write",spur:this.vm.image.isSpur,rcvrClass: rcvr && rcvr.sqClass ? rcvr.sqClass.className() : null, arrClass: arr && arr.sqClass ? arr.sqClass.className() : null, index: index, valueType: typeof value, pos: pos, lim: lim, ok: this.success}, true);
+                var isTextual = arr && this.isKindOf(arr, Squeak.splOb_ClassString);
                 if (arr.isPointers && arr.isPointers()) {
                     arr.pointers[index - 1] = value;
                     arr.dirty = true;
                 } else if (arr.isWords && arr.isWords()) {
-                    var w = this.stackSigned32BitInt(0); // may fail if not int
-                    if (!this.success) { this.success = true; return false; }
-                    arr.words[index - 1] = w;
+                    var wordValue;
+                    if (isTextual) {
+                        if (!(value && value.sqClass === this.vm.specialObjects[Squeak.splOb_ClassCharacter])) return false;
+                        wordValue = this.charToInt(value);
+                        if (typeof wordValue !== "number") return false;
+                    } else {
+                        wordValue = this.stackSigned32BitInt(0); // may fail if not int
+                        if (!this.success) { this.success = true; return false; }
+                    }
+                    arr.words[index - 1] = wordValue;
                 } else if (arr.isBytes && arr.isBytes()) {
                     var byte;
-                    if (this.isA(arr, Squeak.splOb_ClassString)) {
+                    if (isTextual) {
                         if (!(value && value.sqClass === this.vm.specialObjects[Squeak.splOb_ClassCharacter])) return false;
                         byte = this.charToInt(value) & 0xFF;
                     } else {
@@ -277,7 +290,7 @@ Object.subclass('Squeak.Primitives',
                     this.vm.push(arr);
                     this.vm.push(index);
                     this.vm.push(value);
-                    var res = this.objectAtPut(false, this.isA(arr, Squeak.splOb_ClassString), false);
+                    var res = this.objectAtPut(false, isTextual, false);
                     if (!this.success) return false;
                     this.vm.pop(); this.vm.pop(); this.vm.pop();
                 }


### PR DESCRIPTION
## Summary
- treat String subclasses as textual in primitiveNext/primitiveNextPut and reuse the subclass-aware flag for fallback access
- coerce word-based textual storage through charFromInt/charToInt so WideString streams read/write Characters consistently
- add a Node regression harness covering ByteString and WideString stream coercion and document how to run it

## Testing
- node tests/vm-coercion/stream-coercion.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e232d683e0832a8e9268943c3c0819