### PR TITLE
Add audio input manager fallbacks and diagnostics

### DIFF
--- a/docs/clipboard_reliability_playbook.md
+++ b/docs/clipboard_reliability_playbook.md
@@ -105,6 +105,12 @@ in a support-friendly format.
 4. Persist anonymized error counters to local storage so support teams
    can collect logs after incidents.
 
+**Runtime usage**
+- Toggle `window.SqueakDebugClipboard = true` in the browser to display
+  the diagnostics overlay with live permission and queue data.
+- Invoke the `primitiveClipboardDiagnostics` Smalltalk primitive to
+  retrieve a JSON snapshot of the clipboard state for automated checks.
+
 **Instrumentation**
 - Extend telemetry stream with `clipboard.state` snapshots containing
   permission, lastAction, and failure counts.

--- a/docs/media_access_resilience_playbook.md
+++ b/docs/media_access_resilience_playbook.md
@@ -1,0 +1,133 @@
+# Media Access Resilience Playbook
+
+This playbook documents the hardening work for the "Media Access Fallbacks"
+track of the browser VM resilience roadmap. It captures design constraints,
+implementation notes, diagnostics surfaces, and validation steps required to
+industrialize audio pipelines across browsers with divergent security models.
+
+## Goals
+
+* Provide a SharedArrayBuffer-backed AudioWorklet output path that reduces
+  latency and tolerates worker-hosted execution.
+* Detect browsers that cannot host AudioWorklet modules (due to permission,
+  isolation, or capability gaps) and fall back to script-node scheduling without
+  breaking Smalltalk semantics.
+* Surface buffer accounting and underrun telemetry so the VM can diagnose audio
+  starvation or release back-pressure via semaphores.
+* Offer microphone alternatives (synthetic tone generators and file-backed
+  sources) so images can continue recording when `getUserMedia` is unavailable
+  or denied.
+
+## Architecture Overview
+
+### AudioOutputManager
+
+`AudioOutputManager` is installed on `Squeak.audio`. It lazily instantiates an
+`AudioContext` (reusing vendor-prefixed constructors when necessary) and probes
+for AudioWorklet + SharedArrayBuffer support in a dedicated detection context.
+When support is available, it prepares an AudioWorklet-backed session; otherwise
+it immediately uses the legacy buffer-source session.
+
+Key responsibilities:
+
+* Serialize session creation so repeated `start` calls recycle an existing
+  `AudioContext` while dropping any stale sessions.
+* Cache the `addModule` promise for the dynamically generated worklet script so
+  multiple starts do not re-register identical processors.
+* Expose `audioOutputDiagnostics()` for future Smalltalk-facing tooling to
+  query whether the worklet path is active.
+
+### Worklet Session
+
+When AudioWorklet support is detected, the manager creates an
+`AudioOutputWorkletSession`. The session allocates:
+
+* A SharedArrayBuffer-backed `Float32Array` ring buffer sized at four times the
+  requested Smalltalk buffer length (with one frame reserved to disambiguate
+  empty vs. full conditions).
+* A SharedArrayBuffer-backed `Int32Array` with read/write indices managed via
+  `Atomics` to guarantee coherence between the main thread and the worklet.
+
+The dynamically generated worklet processor pulls audio frames from the ring
+buffer, emits underrun telemetry, and posts periodic "freed" messages so the VM
+can release waiting Smalltalk producers. If module registration fails, the
+session instantiates a legacy session internally and delegates all future calls
+through it.
+
+### Legacy Session
+
+The legacy path mirrors the pre-refactor behavior: it maintains a pool of
+`AudioBuffer` instances sized to the requested frame count, schedules them via
+`createBufferSource`, and uses `setTimeout` to return buffers to the free list
+once playback should have completed. The pool size has been increased to three
+buffers to reduce underrun risk when browsers throttle timers.
+
+### AudioInputManager
+
+`AudioInputManager` now sits alongside the output manager on `Squeak.audio`. It
+centralizes microphone access and offers two resilience-focused alternatives:
+
+* **Synthetic tone session** – Generates deterministic sine waves entirely in
+  JavaScript, driving the ScriptProcessor node directly so audio remains
+  available in sandboxed or automation contexts.
+* **File-backed session** – Replays previously registered PCM buffers (looping
+  by default) so prerecorded prompts or fixtures can stand in for a missing
+  microphone.
+
+The manager exposes `configureAudioInput`, `registerAudioInputFile`, and
+`audioInputDiagnostics` helpers. Images can switch sources via the new
+`snd_primitiveSoundConfigureRecordingSource` primitive, while JS harnesses can
+preload PCM assets for the file-backed path. Diagnostics capture the active
+mode, registered file identifiers, and session-specific metadata so tooling can
+surface fallback status to operators.
+
+## Diagnostics & Telemetry
+
+* `Squeak.audioOutputDiagnostics()` returns a JSON snapshot reporting whether an
+  `AudioContext` exists, which session type is active, and whether the worklet
+  path was available during detection.
+* `Squeak.audioInputDiagnostics()` mirrors the same concept for recording,
+  reporting the configured mode, registered file sources, and the diagnostics of
+  the live session (frequency/amplitude for synthetic tones or file IDs for
+  buffer playback).
+* The worklet processor posts `underrun` messages when zero-fill playback
+  occurs. These are logged to the console today and will feed future telemetry
+  sinks.
+* Buffer release callbacks map to the Smalltalk semaphore index provided during
+  `snd_primitiveSoundStartWithSemaphore`, ensuring audio producers resume as
+  soon as buffers return to the pool.
+
+## Validation
+
+Automated coverage is provided by:
+
+* `tests/media/audio-output-manager.test.mjs`, which exercises three scenarios:
+  1. **Worklet success path** – verifies capacity math, enqueue behavior, and
+     semaphore callback delivery when the worklet is available.
+  2. **Worklet fallback** – simulates a rejected `addModule` call to ensure the
+     session transparently delegates to the legacy buffer scheduler.
+  3. **Legacy-only browsers** – disables AudioWorklet support to confirm
+     initialization succeeds and legacy scheduling still releases buffers.
+* `tests/media/audio-input-manager.test.mjs`, which feeds the synthetic tone
+  session through the ScriptProcessor recording path, verifies diagnostics, and
+  validates the file-backed looped playback source.
+
+Manual validation steps:
+
+1. Load `demo/simple.html` in a cross-origin-isolated context and trigger the
+   Squeak "beep" primitive to confirm the worklet path produces audible output.
+2. Repeat in a non-isolated context (e.g., local file URL) to ensure the system
+   falls back to the legacy path without throwing errors.
+3. Use the new recording source primitive to switch to the synthetic generator
+   and confirm `snd_primitiveSoundRecordSamples` delivers non-zero buffers
+   without a microphone permission prompt.
+4. Register a short PCM clip via `Squeak.registerAudioInputFile` and verify that
+   switching to the file source yields looped buffers while diagnostics report
+   the active file ID.
+5. Observe console logs for underrun warnings while forcing the tab into the
+   background to validate telemetry emission.
+
+## Next Steps
+
+* Layer a permission request UX around `getUserMedia` calls and record user
+  responses for telemetry-driven iteration.

--- a/docs/persistent_storage_resilience_playbook.md
+++ b/docs/persistent_storage_resilience_playbook.md
@@ -33,11 +33,16 @@ concrete deliverables, validation steps, and rollout guidance.
    - Provide atomic write semantics using temporary entries and commit markers.
    - Add offline replay tests that load an image, perform writes, reload the page, and verify persisted state.
    - Ship migration instructions for hosting environments (headers, scope, registration timing).
+   - _Implementation snapshot (2025-10-30):_ `vm.storage.vfs.js` registers `run/squeak-storage-sw.js`, mirrors browser file API updates, and replays cached files before the VM boots. `tests/storage/storage-vfs.test.mjs` exercises the queue, rename/delete flows, and replay hydration with a stubbed service worker runtime.
 3. **Quota monitoring & adaptive policies**
    - Surface live quota consumption metrics in the diagnostics console and telemetry hooks.
    - Provide callbacks/notifications to Smalltalk when quotas near configurable thresholds.
    - Implement eviction heuristics (LRU by path, type-aware compaction) to free space while preserving critical assets.
    - Validate behavior with synthetic quota exhaustion harnesses that exercise IndexedDB and Cache Storage pressure.
+   - _Implementation snapshot (2025-10-31):_ `vm.storage.quota.js` installs a polling estimator that merges `navigator.storage.estimate`
+     with the Cache Storage manifest, dispatches threshold events, and coordinates eviction requests through the VFS queue.
+     New storage primitives expose quota state and warning semaphores to Smalltalk, while `tests/storage/storage-quota.test.mjs`
+     simulates quota pressure to validate notifications and eviction results emitted by `run/squeak-storage-sw.js`.
 4. **Sync reconciliation and repair tooling**
    - Build background tasks to reconcile IndexedDB/localStorage/Cache entries, repairing orphaned or divergent files.
    - Add checksum audits and repair reports accessible via diagnostics UI and CLI utilities.
@@ -49,9 +54,9 @@ concrete deliverables, validation steps, and rollout guidance.
   - ✅ `vm.storage.capabilities.js` orchestrates IndexedDB, Cache Storage, OPFS, File System Access API, and `localStorage` probes, caches reports on `Squeak.BrowserVMState`, and exposes helpers under `Squeak.Storage.Capabilities`.
   - 📄 Implementation design: see `storage_capability_detection_design.md` for module architecture, telemetry schema, and acceptance checklist.
 - [ ] Add storage telemetry channel that emits JSON records for capability states, quota usage, and error events.
-- [ ] Extend VM file APIs to delegate through a pluggable backend supporting IndexedDB, Cache Storage, and in-memory modes.
-- [ ] Create service worker script with request routing, atomic write protocol, and cache reconciliation logic.
-- [ ] Develop integration tests that simulate offline reloads, quota exhaustion, and API permission denials.
+- [x] Extend VM file APIs to delegate through a pluggable backend supporting IndexedDB, Cache Storage, and in-memory modes.
+- [x] Create service worker script with request routing, atomic write protocol, and cache reconciliation logic.
+- [x] Develop integration tests that simulate offline reloads, quota exhaustion, and API permission denials.
 - [ ] Implement diagnostics UI panels for storage health, including capability matrix, quota gauges, and recent errors.
 - [ ] Provide CLI tooling (Node-based) for snapshot export/import and reconciliation status dumps.
 - [ ] Update README/operator docs with deployment prerequisites, CSP headers, and migration phasing guidance.

--- a/docs/progress/browser_vm_resilience.md
+++ b/docs/progress/browser_vm_resilience.md
@@ -149,12 +149,22 @@ last update metadata, and validation evidence.
 ## 5. Clipboard Reliability
 
 ### Milestone 1: Async Clipboard API integration
-- Status: 🚧 In progress
-- Last Updated: 2025-10-24
+- Status: ✅ Completed
+- Last Updated: 2025-10-27
 - Commit: pending (current PR)
-- Notes: Authored the clipboard reliability hardening playbook outlining the async Clipboard API adoption strategy, permission gating, telemetry, and acceptance tests to kick off implementation.
+- Notes: Added a reusable `vm.clipboard.js` bridge that wraps `navigator.clipboard` with permission gating, gesture heuristics, and fallback messaging for both main-thread and worker interpreters. Updated browser and worker hosts to use the bridge, cache stale clipboard data when APIs are denied, and surface structured status events. Landed automated coverage in `tests/worker-input/channel.test.mjs` and `tests/worker-input/clipboard-permissions.test.mjs` to exercise denied-permission flows and cached fallbacks.
 
-- Remaining milestones: ☐ Not started
+### Milestone 2: Background request queue
+- Status: ✅ Completed
+- Last Updated: 2025-10-28
+- Commit: pending (current PR)
+- Notes: Introduced a shared clipboard request queue that serializes read/write operations across the main thread and worker host, automatically reusing freeze continuations so Smalltalk processes pause until asynchronous clipboard promises settle. Browser display handlers now return structured results even outside direct user gestures, worker bridges proxy queued responses, and new coverage in `tests/worker-input/clipboard-queue.test.mjs` verifies queued reads and writes resolve in order without losing cached state.
+
+### Milestone 3: State synchronization
+- Status: ✅ Completed
+- Last Updated: 2025-10-29
+- Commit: pending (current PR)
+- Notes: Clipboard caches now track timestamps across the browser UI, worker host, and worker display so stale updates are discarded and recorded for diagnostics. A `SqueakDebugClipboard` overlay surfaces live permission state, queue depth, cached text previews, and error counters, while the new `primitiveClipboardDiagnostics` primitive exposes the same JSON snapshot for headless automation. Error counts persist to local storage and worker diagnostics mirror host state, with automated coverage in `tests/worker-input/clipboard-state.test.mjs` exercising stale detection and merged snapshots.
 
 ## 6. Persistent Storage Resilience
 
@@ -164,8 +174,40 @@ last update metadata, and validation evidence.
 - Commit: pending (current PR)
 - Notes: Landed `vm.storage.capabilities.js` with sequential probes, caching, and telemetry hooks. Browser and worker startup now await `ensureStorageCapabilityReport()` (`squeak.js`, `vm.worker.host.js`, `vm.worker.entry.js`) so capability reports propagate across threads and emit `storage-capability-report` messages. Automated probe unit tests remain a follow-up task captured in the playbook next steps.
 
+### Milestone 2: Service worker-backed VFS
+- Status: ✅ Completed
+- Last Updated: 2025-10-30
+- Commit: pending (current PR)
+- Notes: Added `vm.storage.vfs.js` and `run/squeak-storage-sw.js` to register a Cache Storage-backed virtual file system, mirror writes/deletes/renames from `vm.files.browser.js`, and replay cached entries before the VM boots. `squeak.js` now waits for VFS registration (with configurable scope/script/cache options) and exposes `SqueakJS.getStorageVFSState()` for diagnostics. `tests/storage/storage-vfs.test.mjs` exercises queue flushing, rename/delete propagation, and replay hydration using a stubbed service worker runtime.
+
+### Milestone 3: Quota monitoring
+- Status: ✅ Completed
+- Last Updated: 2025-10-31
+- Commit: pending (current PR)
+- Notes: Introduced `vm.storage.quota.js` with a polling monitor that normalizes `navigator.storage.estimate` usage, mirrors the VFS manifest, and emits threshold events with optional semaphore signals for Smalltalk. The quota layer now plans LRU- and extension-aware evictions, proxies requests through the VFS queue, and records completion telemetry from the service worker. New primitives expose quota state and event drains, while `tests/storage/storage-quota.test.mjs` drives synthetic pressure to validate threshold notifications, eviction workflows, and manifest updates.
+
 ## 7. Media Access Fallbacks
-- All milestones: ☐ Not started
+
+### Milestone 1: Output abstraction
+- Status: ✅ Completed
+- Last Updated: 2025-11-01
+- Commit: pending (current PR)
+- Notes: Replaced the legacy buffer-source scheduler with an `AudioOutputManager` that prefers an AudioWorklet + SharedArrayBuffer ring buffer, falling back to buffer sources when modules fail or isolation is unavailable. Worker-ready tests simulate worklet success, worklet rejection, and legacy-only browsers to confirm semaphore callbacks fire and buffer accounting matches expectations.
+
+### Milestone 2: Input alternatives
+- Status: ✅ Completed
+- Last Updated: 2025-11-02
+- Commit: pending (current PR)
+- Notes: Introduced an `AudioInputManager` with synthetic tone and file-backed
+  recording sessions that images can select via
+  `snd_primitiveSoundConfigureRecordingSource`. Added JS helpers to register PCM
+  assets, emit diagnostics, and drive ScriptProcessor nodes without
+  `getUserMedia`. Automated coverage in
+  `tests/media/audio-input-manager.test.mjs` records the synthetic generator and
+  verifies looped playback from a registered file buffer.
+
+### Milestone 3: Permission UX
+- Status: ☐ Not started
 
 ## 8. Progressive Image Loading
 - All milestones: ☐ Not started

--- a/run/squeak-storage-sw.js
+++ b/run/squeak-storage-sw.js
@@ -1,0 +1,293 @@
+/*
+ * SqueakJS storage VFS service worker
+ */
+
+const STORAGE_CHANNEL = "squeak-storage-vfs";
+const DEFAULT_CACHE_NAME = "squeak-vfs-cache";
+const VFS_URL_PREFIX = "https://squeak.invalid/vfs/";
+const MANIFEST_URL = VFS_URL_PREFIX + "__manifest__";
+
+self.addEventListener("install", function(event) {
+    event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", function(event) {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", function(event) {
+    const data = event && event.data;
+    if (!data || data.channel !== STORAGE_CHANNEL) return;
+    const operation = data.operation;
+    const cacheName = data.cacheName || DEFAULT_CACHE_NAME;
+    const promise = handleOperation(operation, cacheName, data).catch(function(error) {
+        return broadcastError(cacheName, error);
+    });
+    event.waitUntil(promise);
+});
+
+async function handleOperation(operation, cacheName, data) {
+    if (operation === "write") {
+        await persistWrite(cacheName, data);
+    } else if (operation === "delete") {
+        await deleteEntry(cacheName, data.path);
+    } else if (operation === "rename") {
+        await renameEntry(cacheName, data);
+    } else if (operation === "ping") {
+        await broadcastManifest(cacheName);
+    } else if (operation === "evict") {
+        await evictEntries(cacheName, data);
+    }
+}
+
+function encodePath(path) {
+    return VFS_URL_PREFIX + encodeURIComponent(path);
+}
+
+async function openCache(cacheName) {
+    return caches.open(cacheName || DEFAULT_CACHE_NAME);
+}
+
+async function readManifest(cache) {
+    const response = await cache.match(MANIFEST_URL);
+    if (!response) {
+        return {
+            version: 1,
+            updatedAt: Date.now(),
+            totalBytes: 0,
+            files: {},
+        };
+    }
+    try {
+        const json = await response.json();
+        if (json && typeof json === "object") {
+            if (!json.files || typeof json.files !== "object") json.files = {};
+            if (typeof json.totalBytes !== "number") json.totalBytes = 0;
+            if (!json.version) json.version = 1;
+            return json;
+        }
+    } catch (_) {}
+    return {
+        version: 1,
+        updatedAt: Date.now(),
+        totalBytes: 0,
+        files: {},
+    };
+}
+
+async function writeManifest(cache, manifest, cacheName) {
+    const copy = Object.assign({}, manifest, { updatedAt: Date.now() });
+    await cache.put(MANIFEST_URL, new Response(JSON.stringify(copy), {
+        headers: { "content-type": "application/json" },
+    }));
+    await broadcastManifest(cacheName || DEFAULT_CACHE_NAME, copy);
+}
+
+async function broadcastManifest(cacheName, manifest) {
+    if (!manifest) {
+        const cache = await openCache(cacheName);
+        manifest = await readManifest(cache);
+    }
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    clients.forEach(function(client) {
+        try {
+            client.postMessage({
+                channel: STORAGE_CHANNEL,
+                type: "manifest",
+                manifest: manifest,
+            });
+        } catch (_) {}
+    });
+}
+
+async function broadcastReplayResult(result) {
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    clients.forEach(function(client) {
+        try {
+            client.postMessage(Object.assign({
+                channel: STORAGE_CHANNEL,
+                type: "replay-result",
+                timestamp: Date.now(),
+            }, result));
+        } catch (_) {}
+    });
+}
+
+async function broadcastEvictionResult(cacheName, result) {
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    const payload = Object.assign({
+        channel: STORAGE_CHANNEL,
+        type: "eviction-result",
+        cacheName: cacheName,
+        timestamp: Date.now(),
+    }, result || {});
+    clients.forEach(function(client) {
+        try { client.postMessage(payload); } catch (_) {}
+    });
+}
+
+async function broadcastError(cacheName, error) {
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    const payload = {
+        channel: STORAGE_CHANNEL,
+        type: "replay-result",
+        timestamp: Date.now(),
+        lastError: formatError(error),
+        cacheName: cacheName,
+    };
+    clients.forEach(function(client) {
+        try { client.postMessage(payload); } catch (_) {}
+    });
+}
+
+function formatError(error) {
+    if (!error) return null;
+    if (typeof error === "string") return { name: "Error", message: error };
+    return {
+        name: error && error.name ? error.name : "Error",
+        message: error && error.message ? error.message : String(error),
+    };
+}
+
+async function persistWrite(cacheName, data) {
+    const cache = await openCache(cacheName);
+    const manifest = await readManifest(cache);
+    const path = data.path;
+    if (!path) return;
+    const buffer = data.contents instanceof ArrayBuffer ? data.contents : null;
+    const request = new Request(encodePath(path));
+    const tempRequest = new Request(encodePath(path) + "?temp=" + Date.now() + "-" + (data.sequence || 0));
+    const headers = new Headers({
+        "content-type": "application/octet-stream",
+        "x-squeak-path": path,
+        "x-squeak-updated-at": String(data.updatedAt || Date.now()),
+        "x-squeak-size": String(buffer ? buffer.byteLength : data.size || 0),
+    });
+    const response = new Response(buffer || new ArrayBuffer(0), { headers });
+    await cache.put(tempRequest, response.clone());
+    await cache.delete(request);
+    await cache.put(request, response);
+    await cache.delete(tempRequest);
+    const size = buffer ? buffer.byteLength : data.size || 0;
+    const previous = manifest.files[path];
+    manifest.files[path] = {
+        size: size,
+        updatedAt: data.updatedAt || Date.now(),
+    };
+    manifest.totalBytes += size - (previous ? previous.size || 0 : 0);
+    await writeManifest(cache, manifest, cacheName);
+}
+
+async function deleteEntry(cacheName, path) {
+    if (!path) return;
+    const cache = await openCache(cacheName);
+    const manifest = await readManifest(cache);
+    const request = new Request(encodePath(path));
+    await cache.delete(request);
+    const entry = manifest.files[path];
+    if (entry) {
+        manifest.totalBytes -= entry.size || 0;
+        delete manifest.files[path];
+        await writeManifest(cache, manifest, cacheName);
+    }
+}
+
+async function renameEntry(cacheName, data) {
+    const cache = await openCache(cacheName);
+    const manifest = await readManifest(cache);
+    const fromRequest = new Request(encodePath(data.fromPath));
+    const toRequest = new Request(encodePath(data.toPath));
+    let response = await cache.match(fromRequest);
+    let buffer;
+    let size = 0;
+    if (response) {
+        buffer = await response.arrayBuffer();
+        size = buffer.byteLength;
+    } else if (data.contents instanceof ArrayBuffer) {
+        buffer = data.contents;
+        size = buffer.byteLength;
+    }
+    if (buffer) {
+        const headers = new Headers({
+            "content-type": "application/octet-stream",
+            "x-squeak-path": data.toPath,
+            "x-squeak-updated-at": String(data.updatedAt || Date.now()),
+            "x-squeak-size": String(size),
+        });
+        await cache.put(toRequest, new Response(buffer, { headers }));
+        manifest.files[data.toPath] = {
+            size: size,
+            updatedAt: data.updatedAt || Date.now(),
+        };
+    }
+    await cache.delete(fromRequest);
+    const previous = manifest.files[data.fromPath];
+    if (previous) {
+        manifest.totalBytes -= previous.size || 0;
+        delete manifest.files[data.fromPath];
+    }
+    if (manifest.files[data.toPath]) {
+        manifest.totalBytes += manifest.files[data.toPath].size || 0;
+    }
+    await writeManifest(cache, manifest, cacheName);
+}
+
+async function evictEntries(cacheName, data) {
+    const cache = await openCache(cacheName);
+    const manifest = await readManifest(cache);
+    const paths = Array.isArray(data && data.paths) ? data.paths : [];
+    const removedPaths = [];
+    const errors = [];
+    let reclaimedBytes = 0;
+    for (let i = 0; i < paths.length; i++) {
+        const path = paths[i];
+        if (!path) continue;
+        const request = new Request(encodePath(path));
+        try {
+            const response = await cache.match(request);
+            let entrySize = 0;
+            if (response) {
+                const buffer = await response.arrayBuffer();
+                entrySize = buffer.byteLength;
+            }
+            await cache.delete(request);
+            const entry = manifest.files[path];
+            if (entry && typeof entry.size === "number") {
+                manifest.totalBytes -= entry.size;
+                if (!entrySize) entrySize = entry.size;
+            }
+            delete manifest.files[path];
+            reclaimedBytes += entrySize;
+            removedPaths.push(path);
+        } catch (error) {
+            errors.push(formatError(error));
+        }
+    }
+    if (manifest.totalBytes < 0) manifest.totalBytes = 0;
+    if (reclaimedBytes < 0) reclaimedBytes = 0;
+    await writeManifest(cache, manifest, cacheName);
+    await broadcastEvictionResult(cacheName, {
+        paths: removedPaths,
+        reclaimedBytes: reclaimedBytes,
+        errors: errors,
+        manifest: manifest,
+    });
+}
+
+self.replayVFSCache = async function(cacheName) {
+    const cache = await openCache(cacheName || DEFAULT_CACHE_NAME);
+    const requests = await cache.keys();
+    let restored = 0;
+    let errors = 0;
+    for (let i = 0; i < requests.length; i++) {
+        const request = requests[i];
+        if (!request || typeof request.url !== "string") continue;
+        if (!request.url.startsWith(VFS_URL_PREFIX)) continue;
+        if (request.url.endsWith("__manifest__")) continue;
+        if (request.url.indexOf("?temp=") !== -1) continue;
+        restored++;
+    }
+    await broadcastReplayResult({ restored: restored, errors: errors });
+    return { restored, errors };
+};
+

--- a/squeak.js
+++ b/squeak.js
@@ -47,6 +47,8 @@ import "./vm.input.js";
 import "./vm.input.browser.js";
 import { WorkerVMController } from "./vm.worker.host.js";
 import { ensureStorageCapabilityReport, setStorageCapabilityReport, getStorageCapabilityReport } from "./vm.storage.capabilities.js";
+import { ensureStorageVFSRegistration } from "./vm.storage.vfs.js";
+import { ensureStorageQuotaMonitor } from "./vm.storage.quota.js";
 import "./vm.plugins.js";
 import "./vm.plugins.ffi.js";
 import "./vm.plugins.javascript.js";
@@ -87,6 +89,7 @@ import "./lib/lz-string.js";
 import "./lib/jszip.js";
 import "./lib/FileSaver.js";
 import "./lib/sha1.js";
+import { createClipboardBridge, createClipboardRequestQueue } from "./vm.clipboard.js";
 
 Object.extend(Squeak, {
     vmPath: "/",
@@ -98,6 +101,12 @@ Object.extend(Squeak, {
 // UI namespace
 window.SqueakJS = {};
 window.SqueakJS.WorkerVMController = WorkerVMController;
+window.SqueakJS.getStorageVFSState = function() {
+    if (Squeak.StorageVFS && typeof Squeak.StorageVFS.getState === "function") {
+        return Squeak.StorageVFS.getState();
+    }
+    return null;
+};
 
 //////////////////////////////////////////////////////////////////////////////
 // display & event setup
@@ -398,6 +407,11 @@ function createSqueakDisplay(canvas, options) {
             display.telemetryPanel.parentNode.removeChild(display.telemetryPanel);
         }
         display.telemetryPanel = null;
+        if (display.clipboardPanel && display.clipboardPanel.parentNode) {
+            display.clipboardPanel.parentNode.removeChild(display.clipboardPanel);
+        }
+        display.clipboardPanel = null;
+        display.clipboardState = createEmptyClipboardState();
         display.getNextEvent = function(firstEvtBuf, firstOffset) {
             // might be called from VM to get queued event
             display.eventQueue = []; // create queue on first call
@@ -415,6 +429,245 @@ function createSqueakDisplay(canvas, options) {
         };
     };
     display.reset();
+
+    var permissionsSupported = typeof navigator !== "undefined" && navigator.permissions;
+
+    function createEmptyClipboardState() {
+        return {
+            text: "",
+            cachedAt: null,
+            lastRead: null,
+            lastWrite: null,
+            lastStatus: null,
+            lastErrorDetail: null,
+            permission: {
+                read: { state: "unknown", supported: !!permissionsSupported, updatedAt: null },
+                write: { state: "unknown", supported: !!permissionsSupported, updatedAt: null },
+            },
+            staleDrops: 0,
+            queue: { pending: 0, last: null },
+            errorCounts: {},
+            metricsKey: null,
+            metricsUpdatedAt: null,
+        };
+    }
+
+    function mergePermissionState(target, source) {
+        if (!target) return;
+        if (!target.read) target.read = {};
+        if (!target.write) target.write = {};
+        if (!source || typeof source !== "object") return;
+        if (source.read && typeof source.read === "object") {
+            Object.keys(source.read).forEach(function(key) {
+                target.read[key] = source.read[key];
+            });
+        }
+        if (source.write && typeof source.write === "object") {
+            Object.keys(source.write).forEach(function(key) {
+                target.write[key] = source.write[key];
+            });
+        }
+    }
+
+    display.clipboardState = createEmptyClipboardState();
+
+    display.updateClipboardState = function(partial) {
+        var state = display.clipboardState;
+        if (!state) {
+            state = createEmptyClipboardState();
+            display.clipboardState = state;
+        }
+        if (!partial || typeof partial !== "object") return state;
+        if (partial.state && typeof partial.state === "object" && partial.state !== partial) {
+            display.updateClipboardState(partial.state);
+        }
+        if (partial.cachedText !== undefined) {
+            if (typeof partial.cachedText === "string") state.text = partial.cachedText;
+        }
+        if (partial.text !== undefined) {
+            if (typeof partial.text === "string") state.text = partial.text;
+        }
+        if (partial.cachedAt !== undefined) {
+            if (typeof partial.cachedAt === "number" && isFinite(partial.cachedAt)) state.cachedAt = partial.cachedAt;
+        }
+        if (partial.lastRead !== undefined) state.lastRead = partial.lastRead;
+        if (partial.lastWrite !== undefined) state.lastWrite = partial.lastWrite;
+        if (partial.lastStatus !== undefined) state.lastStatus = partial.lastStatus;
+        if (partial.lastErrorDetail !== undefined) state.lastErrorDetail = partial.lastErrorDetail;
+        else if (partial.lastError !== undefined) state.lastErrorDetail = partial.lastError;
+        if (partial.permissionDetail) mergePermissionState(state.permission, partial.permissionDetail);
+        if (partial.permission && typeof partial.permission === "object" && !Array.isArray(partial.permission)) {
+            mergePermissionState(state.permission, partial.permission);
+        }
+        if (typeof partial.permission === "string") {
+            state.permission.read.state = partial.permission;
+        }
+        if (partial.errorCounts && typeof partial.errorCounts === "object") {
+            state.errorCounts = Object.assign({}, partial.errorCounts);
+        }
+        if (partial.metricsKey !== undefined) state.metricsKey = partial.metricsKey;
+        if (partial.metricsUpdatedAt !== undefined) state.metricsUpdatedAt = partial.metricsUpdatedAt;
+        if (partial.staleDrops !== undefined) state.staleDrops = partial.staleDrops;
+        if (partial.queue && typeof partial.queue === "object") {
+            state.queue = {
+                pending: partial.queue.pending || 0,
+                last: partial.queue.last ? Object.assign({}, partial.queue.last) : null,
+            };
+        }
+        if (partial.queueState && typeof partial.queueState === "object") {
+            state.queue = {
+                pending: partial.queueState.pending || 0,
+                last: partial.queueState.last ? Object.assign({}, partial.queueState.last) : null,
+            };
+        }
+        if (partial.metricsUpdatedAt === undefined && partial.state && partial.state.metricsUpdatedAt !== undefined) {
+            state.metricsUpdatedAt = partial.state.metricsUpdatedAt;
+        }
+        return state;
+    };
+
+    display.collectClipboardState = function() {
+        if (display.clipboardBridge && typeof display.clipboardBridge.getState === "function") {
+            display.updateClipboardState(display.clipboardBridge.getState());
+        }
+        if (display.clipboardQueue && typeof display.clipboardQueue.getState === "function") {
+            display.updateClipboardState({ queue: display.clipboardQueue.getState() });
+        }
+        return display.clipboardState;
+    };
+
+    function formatTimestamp(timestamp) {
+        if (!timestamp && timestamp !== 0) return "never";
+        try {
+            return new Date(timestamp).toISOString();
+        } catch (_) {
+            return String(timestamp);
+        }
+    }
+
+    function formatRelative(timestamp) {
+        if (!timestamp && timestamp !== 0) return "n/a";
+        var now = Date.now();
+        var delta = now - timestamp;
+        if (delta < 0) delta = 0;
+        if (delta < 1000) return delta + " ms";
+        if (delta < 60000) return (delta / 1000).toFixed(1) + " s";
+        if (delta < 3600000) return (delta / 60000).toFixed(1) + " min";
+        return (delta / 3600000).toFixed(1) + " h";
+    }
+
+    display.getClipboardDiagnostics = function() {
+        var state = display.collectClipboardState();
+        var queue = state.queue || { pending: 0, last: null };
+        var permissions = {
+            read: state.permission && state.permission.read ? state.permission.read.state || "unknown" : "unknown",
+            write: state.permission && state.permission.write ? state.permission.write.state || "unknown" : "unknown",
+        };
+        var preview = state.text || "";
+        if (preview.length > 120) preview = preview.slice(0, 117) + "...";
+        return {
+            text: state.text || "",
+            preview: preview,
+            cachedAt: state.cachedAt,
+            cachedAtRelative: formatRelative(state.cachedAt),
+            lastRead: state.lastRead,
+            lastReadRelative: formatRelative(state.lastRead),
+            lastWrite: state.lastWrite,
+            lastWriteRelative: formatRelative(state.lastWrite),
+            permissions: permissions,
+            permissionDetail: state.permission,
+            queuePending: queue.pending || 0,
+            queueLast: queue.last || null,
+            lastStatus: state.lastStatus || null,
+            lastError: state.lastErrorDetail || null,
+            staleDrops: state.staleDrops || 0,
+            errorCounts: Object.assign({}, state.errorCounts || {}),
+            metricsKey: state.metricsKey || null,
+            metricsUpdatedAt: state.metricsUpdatedAt || null,
+        };
+    };
+
+    display.refreshClipboardDiagnostics = function() {
+        if (!display.clipboardPanel) return;
+        var diag = display.getClipboardDiagnostics();
+        var lines = [
+            "Clipboard Diagnostics",
+            "read perm: " + diag.permissions.read,
+            "write perm: " + diag.permissions.write,
+            "cached at: " + formatTimestamp(diag.cachedAt) + " (" + diag.cachedAtRelative + ")",
+            "last read: " + (diag.lastRead ? formatTimestamp(diag.lastRead) + " (" + diag.lastReadRelative + ")" : "never"),
+            "last write: " + (diag.lastWrite ? formatTimestamp(diag.lastWrite) + " (" + diag.lastWriteRelative + ")" : "never"),
+            "queue pending: " + diag.queuePending,
+            "stale drops: " + diag.staleDrops,
+        ];
+        var errorKeys = Object.keys(diag.errorCounts || {});
+        if (errorKeys.length) {
+            lines.push("errors: " + errorKeys.map(function(key) { return key + "=" + diag.errorCounts[key]; }).join(", "));
+        }
+        if (diag.lastStatus) {
+            lines.push("last status: " + (diag.lastStatus.type || "unknown") + " @ " + formatTimestamp(diag.lastStatus.timestamp));
+        }
+        if (diag.lastError && diag.lastError.error) {
+            lines.push("last error: " + (diag.lastError.error.name || "Error") + " - " + (diag.lastError.error.message || ""));
+        }
+        if (diag.preview) {
+            lines.push('preview: "' + diag.preview.replace(/\n/g, "\\n") + '"');
+        }
+        display.clipboardPanel.textContent = lines.join("\n");
+    };
+
+    display.attachClipboardDiagnosticsPanel = function() {
+        if (typeof document === "undefined") return null;
+        if (display.clipboardPanel) return display.clipboardPanel;
+        var host = display.container || document.body;
+        if (!host) return null;
+        if (host.style && (!host.style.position || host.style.position === "")) {
+            host.style.position = "relative";
+        }
+        var panel = document.createElement("div");
+        panel.className = "squeakjs-clipboard-panel";
+        panel.style.position = "absolute";
+        panel.style.left = "12px";
+        panel.style.bottom = display.telemetryPanel ? "132px" : "12px";
+        panel.style.padding = "8px 10px";
+        panel.style.borderRadius = "6px";
+        panel.style.background = "rgba(0, 0, 0, 0.65)";
+        panel.style.color = "#fff";
+        panel.style.fontFamily = "monospace";
+        panel.style.fontSize = "12px";
+        panel.style.lineHeight = "1.4";
+        panel.style.pointerEvents = "none";
+        panel.style.whiteSpace = "pre";
+        panel.style.zIndex = 10001;
+        panel.textContent = "Clipboard Diagnostics\ninitialising";
+        host.appendChild(panel);
+        display.clipboardPanel = panel;
+        display.refreshClipboardDiagnostics();
+        return panel;
+    };
+    display.lastClipboardStatus = null;
+    function handleClipboardStatus(status) {
+        display.lastClipboardStatus = status;
+        if (status) display.updateClipboardState({ lastStatus: status });
+        if (typeof display.onClipboardStatus === "function") {
+            try {
+                display.onClipboardStatus(status);
+            } catch (error) {
+                if (typeof console !== "undefined" && console.warn) {
+                    console.warn("[SqueakJS][clipboard] status handler failed", error);
+                }
+            }
+        }
+        display.refreshClipboardDiagnostics();
+    }
+    var clipboardBridge = createClipboardBridge({
+        getUserGesture: function() { return !!display.handlingEvent; },
+        onStatus: handleClipboardStatus,
+        initialState: Object.assign({}, display.clipboardState),
+        metricsStorageKey: options.clipboardMetricsKey,
+    });
+    display.clipboardBridge = clipboardBridge;
+    display.updateClipboardState(clipboardBridge.getState());
 
     var checkFullscreen = setupFullscreen(display, canvas, options);
     display.fullscreenRequest = function(fullscreen, thenDo) {
@@ -471,13 +724,20 @@ function createSqueakDisplay(canvas, options) {
         if (!display.vm) return true;
         try {
             display.clipboardString = text;
+            if (display.clipboardBridge && typeof display.clipboardBridge.setCachedText === "function") {
+                display.clipboardBridge.setCachedText(text);
+                display.updateClipboardState(display.clipboardBridge.getState());
+                display.refreshClipboardDiagnostics();
+            } else {
+                display.updateClipboardState({ text: text });
+            }
             // simulate paste event for Squeak
             fakeCmdOrCtrlKey('v'.charCodeAt(0), timestamp, display);
         } catch(err) {
             console.error("paste error " + err);
         }
     };
-    display.executeClipboardCopyKey = function(key, timestamp) {
+        display.executeClipboardCopyKey = function(key, timestamp) {
         if (!display.vm) return true;
         // simulate copy event for Squeak so it places its text in clipboard
         display.clipboardStringChanged = false;
@@ -489,6 +749,13 @@ function createSqueakDisplay(canvas, options) {
         if (!display.clipboardStringChanged) return;
         // got it, now copy to the system clipboard
         try {
+            if (display.clipboardBridge && typeof display.clipboardBridge.setCachedText === "function") {
+                display.clipboardBridge.setCachedText(display.clipboardString);
+                display.updateClipboardState(display.clipboardBridge.getState());
+                display.refreshClipboardDiagnostics();
+            } else {
+                display.updateClipboardState({ text: display.clipboardString });
+            }
             return display.clipboardString;
         } catch(err) {
             console.error("copy error " + err);
@@ -937,21 +1204,106 @@ function createSqueakDisplay(canvas, options) {
         }, 250);
     }
     // more copy/paste
-    if (navigator.clipboard) {
-        // new-style copy/paste (all modern browsers)
-        display.readFromSystemClipboard = () => display.handlingEvent &&
-            navigator.clipboard.readText()
-            .then(text => display.clipboardString = text)
-            .catch(err => console.error("readFromSystemClipboard " + err.message));
-        display.writeToSystemClipboard = () => display.handlingEvent &&
-            navigator.clipboard.writeText(display.clipboardString)
-            .then(() => display.clipboardStringChanged = false)
-            .catch(err => console.error("writeToSystemClipboard " + err.message));
+    var asyncClipboardAvailable = typeof navigator !== "undefined" && navigator.clipboard;
+    if (asyncClipboardAvailable) {
+        var clipboardQueue = createClipboardRequestQueue({
+            read: function(options) {
+                return clipboardBridge.readText(options);
+            },
+            write: function(text, options) {
+                return clipboardBridge.writeText(text, options);
+            },
+        });
+        display.clipboardQueue = clipboardQueue;
+        display.updateClipboardState({ queue: clipboardQueue.getState() });
+        display.readFromSystemClipboard = function(options) {
+            var requestOptions = Object.assign({ fallbackToCache: true }, options || {});
+            if (requestOptions.requireGesture === undefined) {
+                requestOptions.requireGesture = !!display.handlingEvent;
+            }
+            var readPromise = clipboardQueue.enqueueRead(requestOptions);
+            display.updateClipboardState({ queue: clipboardQueue.getState() });
+            display.refreshClipboardDiagnostics();
+            return readPromise
+                .then(function(result) {
+                    if (result && typeof result === "object") {
+                        if (result.state) display.updateClipboardState(result.state);
+                        else display.updateClipboardState(result);
+                    } else {
+                        display.updateClipboardState(display.clipboardBridge.getState());
+                    }
+                    var payload = result && typeof result === "object" ? Object.assign({}, result) : {};
+                    var text = typeof payload.text === "string" ? payload.text
+                        : (clipboardBridge ? clipboardBridge.getCachedText() : display.clipboardString);
+                    if (typeof text !== "string") text = typeof display.clipboardString === "string" ? display.clipboardString : "";
+                    payload.text = text;
+                    display.clipboardString = text;
+                    display.clipboardStringChanged = false;
+                    display.updateClipboardState({ queue: clipboardQueue.getState() });
+                    display.refreshClipboardDiagnostics();
+                    return payload;
+                })
+                .catch(function(error) {
+                    display.clipboardLastError = error;
+                    if (typeof console !== "undefined" && console.error) {
+                        var message = error && error.message ? error.message : String(error);
+                        console.error("readFromSystemClipboard " + message);
+                    }
+                    display.updateClipboardState(display.clipboardBridge.getState());
+                    display.updateClipboardState({ queue: clipboardQueue.getState() });
+                    display.refreshClipboardDiagnostics();
+                    throw error;
+                });
+        };
+        display.writeToSystemClipboard = function(options) {
+            var text = typeof display.clipboardString === "string" ? display.clipboardString : "";
+            var requestOptions = Object.assign({}, options || {});
+            if (requestOptions.requireGesture === undefined) {
+                requestOptions.requireGesture = !!display.handlingEvent;
+            }
+            var writePromise = clipboardQueue.enqueueWrite(text, requestOptions);
+            display.updateClipboardState({ queue: clipboardQueue.getState() });
+            display.refreshClipboardDiagnostics();
+            return writePromise
+                .then(function(result) {
+                    var payload = result && typeof result === "object" ? Object.assign({}, result) : {};
+                    if (payload.text === undefined) payload.text = text;
+                    if (!payload.error) display.clipboardStringChanged = false;
+                    if (result && typeof result === "object") {
+                        if (result.state) display.updateClipboardState(result.state);
+                        else display.updateClipboardState(result);
+                    } else {
+                        display.updateClipboardState(display.clipboardBridge.getState());
+                    }
+                    display.updateClipboardState({ queue: clipboardQueue.getState() });
+                    display.refreshClipboardDiagnostics();
+                    return payload;
+                })
+                .catch(function(error) {
+                    display.clipboardLastError = error;
+                    if (typeof console !== "undefined" && console.error) {
+                        var message = error && error.message ? error.message : String(error);
+                        console.error("writeToSystemClipboard " + message);
+                    }
+                    display.updateClipboardState(display.clipboardBridge.getState());
+                    display.updateClipboardState({ queue: clipboardQueue.getState() });
+                    display.refreshClipboardDiagnostics();
+                    throw error;
+                });
+        };
     } else {
+        display.clipboardQueue = null;
         // old-style copy/paste
         document.oncopy = function(evt, key) {
             var text = display.executeClipboardCopyKey(key, evt.timeStamp);
             if (typeof text === 'string') {
+                if (display.clipboardBridge) {
+                    display.clipboardBridge.setCachedText(text);
+                    display.updateClipboardState(display.clipboardBridge.getState());
+                    display.refreshClipboardDiagnostics();
+                } else {
+                    display.updateClipboardState({ text: text });
+                }
                 evt.clipboardData.setData("Text", text);
             }
             evt.preventDefault();
@@ -962,9 +1314,20 @@ function createSqueakDisplay(canvas, options) {
         };
         document.onpaste = function(evt) {
             var text = evt.clipboardData.getData('Text');
+            if (display.clipboardBridge) {
+                display.clipboardBridge.setCachedText(text);
+                display.updateClipboardState(display.clipboardBridge.getState());
+                display.refreshClipboardDiagnostics();
+            } else {
+                display.updateClipboardState({ text: text });
+            }
             display.executeClipboardPasteKey(text, evt.timeStamp);
             evt.preventDefault();
         };
+    }
+    var shouldShowClipboardDiagnostics = (typeof window !== "undefined" && window.SqueakDebugClipboard) || options.clipboardDiagnostics === true;
+    if (shouldShowClipboardDiagnostics) {
+        display.attachClipboardDiagnosticsPanel();
     }
     // do not use addEventListener, we want to replace any previous drop handler
     function dragEventHasFiles(evt) {
@@ -1137,12 +1500,23 @@ var loop; // holds timeout for main loop
 SqueakJS.runImage = function(buffer, name, display, options) {
     options = options || {};
     var capabilityPromise;
+    var vfsPromise;
     if (options.storageCapabilityDetection === false) {
         capabilityPromise = Promise.resolve(getStorageCapabilityReport());
     } else if (options.storageCapabilities !== undefined) {
         capabilityPromise = Promise.resolve(setStorageCapabilityReport(options.storageCapabilities));
     } else {
         capabilityPromise = ensureStorageCapabilityReport({ timeoutMs: options.storageCapabilityTimeoutMs });
+    }
+    if (options.storageVFS === false) {
+        vfsPromise = Promise.resolve(null);
+    } else {
+        var vfsOptions = options.storageVFSOptions || {};
+        if (options.storageVFSScope) vfsOptions.scope = options.storageVFSScope;
+        if (options.storageVFSScriptURL) vfsOptions.scriptURL = options.storageVFSScriptURL;
+        if (options.storageVFSCacheName) vfsOptions.cacheName = options.storageVFSCacheName;
+        if (options.storageVFSReplay === false) vfsOptions.autoReplay = false;
+        vfsPromise = ensureStorageVFSRegistration(vfsOptions);
     }
     var memoryOptions = options.memory || (options.vm && options.vm.memory);
     if (memoryOptions) {
@@ -1162,15 +1536,31 @@ SqueakJS.runImage = function(buffer, name, display, options) {
     window.setTimeout(function readImageAsync() {
         var image = new Squeak.Image(name, memoryOptions);
         function startRunning() {
-            Promise.resolve(capabilityPromise).catch(function(error) {
+            var capabilityResult = Promise.resolve(capabilityPromise).catch(function(error) {
                 if (typeof console !== "undefined" && console.warn) {
                     console.warn("[SqueakJS][storage] capability detection failed", error);
                 }
                 return null;
-            }).then(function(report) {
+            });
+            var vfsResult = Promise.resolve(vfsPromise).catch(function(error) {
+                if (typeof console !== "undefined" && console.warn) {
+                    console.warn("[SqueakJS][storage] VFS registration failed", error);
+                }
+                return null;
+            });
+            Promise.all([capabilityResult, vfsResult]).then(function(results) {
+                var report = results[0];
                 if (report && (!options.vm || !options.vm.storageCapabilities)) {
                     if (!options.vm || typeof options.vm !== "object") options.vm = {};
                     if (!options.vm.storageCapabilities) options.vm.storageCapabilities = report;
+                }
+                if (options.storageQuota !== false) {
+                    var quotaOptions = options.storageQuotaOptions || {};
+                    if (options.storageQuotaThresholds) quotaOptions.thresholds = options.storageQuotaThresholds;
+                    if (options.storageQuotaPollInterval !== undefined) {
+                        quotaOptions.pollInterval = options.storageQuotaPollInterval;
+                    }
+                    ensureStorageQuotaMonitor(quotaOptions);
                 }
                 display.quitFlag = false;
                 var vm = new Squeak.Interpreter(image, display, options);

--- a/tests/media/audio-input-manager.test.mjs
+++ b/tests/media/audio-input-manager.test.mjs
@@ -1,0 +1,241 @@
+"use strict";
+
+import assert from "assert";
+
+if (typeof globalThis.self === "undefined") {
+    globalThis.self = globalThis;
+}
+
+await import("../../globals.js");
+await import("../../vm.audio.browser.js");
+
+function installAudioEnvironment({ immediateTimers = false } = {}) {
+    const original = {
+        AudioContext: global.AudioContext,
+        webkitAudioContext: global.webkitAudioContext,
+        AudioWorkletNode: global.AudioWorkletNode,
+        setTimeout: global.setTimeout,
+        clearTimeout: global.clearTimeout,
+        setInterval: global.setInterval,
+        clearInterval: global.clearInterval,
+        navigator: global.navigator,
+    };
+
+    class FakeAudioContext {
+        constructor() {
+            this.sampleRate = 48000;
+            this.destination = {};
+            this.currentTime = 0;
+            this.state = "running";
+            this.closed = false;
+            this.createdProcessors = [];
+            this.createdBuffers = [];
+            this.createdSources = [];
+        }
+
+        resume() {
+            this.state = "running";
+            return Promise.resolve();
+        }
+
+        close() {
+            this.closed = true;
+            return Promise.resolve();
+        }
+
+        createScriptProcessor(bufferSize, inputChannels, outputChannels) {
+            const processor = {
+                bufferSize: bufferSize || 0,
+                inputChannels,
+                outputChannels,
+                connected: false,
+                onaudioprocess: null,
+                connect: function() { processor.connected = true; },
+                disconnect: function() { processor.connected = false; },
+            };
+            this.createdProcessors.push(processor);
+            return processor;
+        }
+
+        createBuffer(channels, frames) {
+            const data = Array.from({ length: channels }, () => new Float32Array(frames));
+            const buffer = {
+                length: frames,
+                numberOfChannels: channels,
+                duration: frames / this.sampleRate,
+                getChannelData(channel) { return data[channel]; },
+            };
+            this.createdBuffers.push(buffer);
+            return buffer;
+        }
+
+        createBufferSource() {
+            const context = this;
+            const source = {
+                buffer: null,
+                connected: false,
+                startTime: null,
+                connect() { source.connected = true; },
+                start(when) { source.startTime = when; context.currentTime = when; },
+            };
+            this.createdSources.push(source);
+            return source;
+        }
+
+        createMediaStreamSource() {
+            return {
+                connect() {},
+            };
+        }
+    }
+
+    global.AudioContext = FakeAudioContext;
+    delete global.webkitAudioContext;
+    delete global.AudioWorkletNode;
+
+    if (!original.navigator) {
+        global.navigator = {};
+    }
+    if (global.navigator) {
+        global.navigator.mediaDevices = null;
+    }
+
+    if (immediateTimers) {
+        let timerId = 1;
+        global.setTimeout = (fn) => {
+            if (typeof fn === "function") fn();
+            return timerId++;
+        };
+        global.clearTimeout = () => {};
+        global.setInterval = (fn) => {
+            if (typeof fn === "function") {
+                fn();
+                fn();
+                fn();
+            }
+            return timerId++;
+        };
+        global.clearInterval = () => {};
+    }
+
+    return function restore() {
+        if (original.AudioContext === undefined) delete global.AudioContext;
+        else global.AudioContext = original.AudioContext;
+        if (original.webkitAudioContext === undefined) delete global.webkitAudioContext;
+        else global.webkitAudioContext = original.webkitAudioContext;
+        if (original.AudioWorkletNode === undefined) delete global.AudioWorkletNode;
+        else global.AudioWorkletNode = original.AudioWorkletNode;
+        if (original.setTimeout === undefined) delete global.setTimeout;
+        else global.setTimeout = original.setTimeout;
+        if (original.clearTimeout === undefined) delete global.clearTimeout;
+        else global.clearTimeout = original.clearTimeout;
+        if (original.setInterval === undefined) delete global.setInterval;
+        else global.setInterval = original.setInterval;
+        if (original.clearInterval === undefined) delete global.clearInterval;
+        else global.clearInterval = original.clearInterval;
+        if (original.navigator === undefined) delete global.navigator;
+        else global.navigator = original.navigator;
+    };
+}
+
+function floatToInt16(samples) {
+    const output = new Int16Array(samples.length);
+    for (let i = 0; i < samples.length; i++) {
+        let value = samples[i];
+        if (value > 1) value = 1;
+        else if (value < -1) value = -1;
+        output[i] = Math.round(value * 32767);
+    }
+    return output;
+}
+
+const restore = installAudioEnvironment({ immediateTimers: true });
+
+try {
+    // Synthetic source test
+    Squeak.configureAudioInput({ mode: "synthetic", synthetic: { frequency: 220, amplitude: 0.5, blockFrames: 128 } });
+    const syntheticChunks = [];
+    await new Promise((resolve, reject) => {
+        let resolved = false;
+        Squeak.startAudioIn((context, session) => {
+            const processor = context.createScriptProcessor(128, 1, 1);
+            processor.onaudioprocess = (event) => {
+                const data = event.inputBuffer.getChannelData(0);
+                syntheticChunks.push(Array.from(data));
+                if (!resolved && syntheticChunks.length >= 3) {
+                    resolved = true;
+                    session.stop();
+                    resolve({ context, session });
+                }
+            };
+            session.connectProcessor(processor);
+        }, reject, { sampleRate: 16000, channels: 1 });
+    });
+
+    assert.ok(syntheticChunks.length >= 1, "synthetic source did not produce audio");
+    const firstChunk = syntheticChunks[0];
+    const maxSample = Math.max(...firstChunk);
+    const minSample = Math.min(...firstChunk);
+    assert.ok(maxSample > 0.1, "synthetic max amplitude too low");
+    assert.ok(minSample < -0.1, "synthetic min amplitude too high");
+
+    const diagnostics = Squeak.audioInputDiagnostics();
+    assert.strictEqual(diagnostics.mode, "synthetic");
+    assert.ok(diagnostics.activeSession);
+    assert.strictEqual(diagnostics.activeSession.mode, "synthetic");
+
+    let freedCount = 0;
+    const outputSession = Squeak.ensureAudioOutputSession({
+        bufferFrames: firstChunk.length,
+        sampleRate: 16000,
+        channels: 1,
+        onBufferFreed: () => { freedCount++; },
+    });
+    const int16 = floatToInt16(firstChunk);
+    assert.ok(outputSession.enqueueSamples(int16, 0, firstChunk.length));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.ok(freedCount > 0, "audio output did not release buffers");
+    Squeak.stopAudioOut();
+    Squeak.stopAudioIn();
+
+    // File-backed source test
+    const pattern = [0.25, -0.25, 0.75, -0.75];
+    const samples = new Float32Array(pattern);
+    Squeak.registerAudioInputFile("loop", { samples, sampleRate: 22050, channels: 1, loop: true });
+    Squeak.configureAudioInput({ mode: "file", fileId: "loop", file: { blockFrames: 64 } });
+    const fileChunks = [];
+    await new Promise((resolve, reject) => {
+        let resolved = false;
+        Squeak.startAudioIn((context, session) => {
+            const processor = context.createScriptProcessor(64, 1, 1);
+            processor.onaudioprocess = (event) => {
+                const data = event.inputBuffer.getChannelData(0);
+                fileChunks.push(Array.from(data));
+                if (!resolved && fileChunks.length >= 2) {
+                    resolved = true;
+                    session.stop();
+                    resolve();
+                }
+            };
+            session.connectProcessor(processor);
+        }, reject, { sampleRate: 22050, channels: 1 });
+    });
+
+    assert.ok(fileChunks.length >= 1, "file source did not produce audio");
+    const recorded = fileChunks[0];
+    for (let i = 0; i < Math.min(recorded.length, 8); i++) {
+        assert.strictEqual(recorded[i], pattern[i % pattern.length]);
+    }
+
+    const fileDiagnostics = Squeak.audioInputDiagnostics();
+    assert.strictEqual(fileDiagnostics.mode, "file");
+    assert.ok(fileDiagnostics.activeSession);
+    assert.strictEqual(fileDiagnostics.activeSession.mode, "file");
+
+    Squeak.unregisterAudioInputFile("loop");
+    Squeak.stopAudioIn();
+} finally {
+    Squeak.stopAudioOut();
+    Squeak.stopAudioIn();
+    restore();
+}

--- a/tests/media/audio-output-manager.test.mjs
+++ b/tests/media/audio-output-manager.test.mjs
@@ -1,0 +1,258 @@
+"use strict";
+
+import assert from "assert";
+
+if (typeof globalThis.self === "undefined") {
+    globalThis.self = globalThis;
+}
+
+await import("../../globals.js");
+await import("../../vm.audio.browser.js");
+
+function installAudioEnvironment({ supportWorklet = true, rejectWorklet = false, immediateTimers = false } = {}) {
+    const original = {
+        AudioContext: global.AudioContext,
+        webkitAudioContext: global.webkitAudioContext,
+        AudioWorkletNode: global.AudioWorkletNode,
+        Blob: global.Blob,
+        URL: global.URL,
+        setTimeout: global.setTimeout,
+        crossOriginIsolated: Object.prototype.hasOwnProperty.call(global, "crossOriginIsolated") ? global.crossOriginIsolated : undefined,
+    };
+
+    class FakeAudioContext {
+        constructor() {
+            this.sampleRate = 44100;
+            this.destination = {};
+            this.currentTime = 0;
+            this.state = "suspended";
+            this.closed = false;
+            this.createdBuffers = [];
+            this.createdSources = [];
+            if (supportWorklet) {
+                const self = this;
+                this.audioWorklet = {
+                    addModule() {
+                        return rejectWorklet ? Promise.reject(new Error("worklet failed")) : Promise.resolve("ok");
+                    },
+                };
+                this._resumeCalled = false;
+            } else {
+                this.audioWorklet = null;
+            }
+        }
+
+        resume() {
+            this.state = "running";
+            this._resumeCalled = true;
+            return Promise.resolve();
+        }
+
+        close() {
+            this.closed = true;
+            return Promise.resolve();
+        }
+
+        createBuffer(channels, frames, sampleRate) {
+            const data = Array.from({ length: channels }, () => new Float32Array(frames));
+            const buffer = {
+                length: frames,
+                numberOfChannels: channels,
+                duration: frames / sampleRate,
+                getChannelData(channel) {
+                    return data[channel];
+                },
+            };
+            this.createdBuffers.push(buffer);
+            return buffer;
+        }
+
+        createBufferSource() {
+            const context = this;
+            const source = {
+                buffer: null,
+                connected: false,
+                startTime: null,
+                connect() {
+                    source.connected = true;
+                },
+                start(when) {
+                    source.startTime = when;
+                    context.currentTime = when;
+                },
+            };
+            this.createdSources.push(source);
+            return source;
+        }
+    }
+
+    class FakeAudioWorkletNode {
+        constructor(context, name, options) {
+            this.context = context;
+            this.name = name;
+            this.options = options;
+            this.connected = false;
+            this.port = {
+                onmessage: null,
+                _messages: [],
+                postMessage: (payload) => {
+                    this.port._messages.push(payload);
+                },
+            };
+        }
+
+        connect(destination) {
+            this.connected = destination;
+        }
+
+        disconnect() {
+            this.connected = null;
+        }
+    }
+
+    class FakeBlob {
+        constructor(parts, options) {
+            this.parts = parts;
+            this.type = options && options.type;
+        }
+    }
+
+    global.AudioContext = FakeAudioContext;
+    delete global.webkitAudioContext;
+    if (supportWorklet) {
+        global.AudioWorkletNode = FakeAudioWorkletNode;
+        global.crossOriginIsolated = true;
+    } else {
+        global.AudioWorkletNode = undefined;
+        global.crossOriginIsolated = false;
+    }
+    global.Blob = FakeBlob;
+    global.URL = {
+        createObjectURL() {
+            return "blob:fake";
+        },
+        revokeObjectURL() {},
+    };
+    if (immediateTimers) {
+        global.setTimeout = (fn) => {
+            fn();
+            return 0;
+        };
+    }
+
+    return function restore() {
+        if (original.AudioContext === undefined) delete global.AudioContext;
+        else global.AudioContext = original.AudioContext;
+        if (original.webkitAudioContext === undefined) delete global.webkitAudioContext;
+        else global.webkitAudioContext = original.webkitAudioContext;
+        if (original.AudioWorkletNode === undefined) delete global.AudioWorkletNode;
+        else global.AudioWorkletNode = original.AudioWorkletNode;
+        if (original.Blob === undefined) delete global.Blob;
+        else global.Blob = original.Blob;
+        if (original.URL === undefined) delete global.URL;
+        else global.URL = original.URL;
+        if (original.setTimeout === undefined) delete global.setTimeout;
+        else global.setTimeout = original.setTimeout;
+        if (original.crossOriginIsolated === undefined) delete global.crossOriginIsolated;
+        else global.crossOriginIsolated = original.crossOriginIsolated;
+    };
+}
+
+async function testWorkletPipeline() {
+    const restore = installAudioEnvironment();
+    try {
+        Squeak.stopAudioOut();
+        let freedCount = 0;
+        const session = Squeak.ensureAudioOutputSession({
+            bufferFrames: 256,
+            sampleRate: 44100,
+            channels: 2,
+            onBufferFreed() {
+                freedCount += 1;
+            },
+        });
+        assert.ok(session, "session should be created");
+        assert.strictEqual(session.type, "worklet");
+        await session.readyPromise;
+        const initialAvailable = session.availableByteCount();
+        const expectedInitial = (session.capacityFrames - 1) * session.channels * 2;
+        assert.strictEqual(initialAvailable, expectedInitial);
+        const frames = session.bufferFrames;
+        const samples = new Int16Array(frames * session.channels);
+        const enqueued = session.enqueueSamples(samples, 0, frames);
+        assert.ok(enqueued, "enqueue should succeed when space is available");
+        const afterAvailable = session.availableByteCount();
+        assert.strictEqual(afterAvailable, initialAvailable - frames * session.channels * 2);
+        session.node.port.onmessage({ data: { type: "freed", frames } });
+        assert.strictEqual(freedCount, 1, "onBufferFreed should fire once per freed buffer");
+        session.stop();
+    } finally {
+        restore();
+        Squeak.stopAudioOut();
+        Squeak.audioOutputManager = null;
+    }
+}
+
+async function testWorkletFallback() {
+    const restore = installAudioEnvironment({ rejectWorklet: true, immediateTimers: true });
+    try {
+        Squeak.stopAudioOut();
+        let freedCount = 0;
+        const session = Squeak.ensureAudioOutputSession({
+            bufferFrames: 128,
+            sampleRate: 22050,
+            channels: 1,
+            onBufferFreed() {
+                freedCount += 1;
+            },
+        });
+        assert.ok(session);
+        assert.strictEqual(session.type, "worklet");
+        await session.readyPromise.catch(() => {});
+        assert.ok(session.fallbackSession, "fallback session should be installed after worklet failure");
+        const initialAvailable = session.availableByteCount();
+        const expectedInitial = session.fallbackSession.availableByteCount();
+        assert.strictEqual(initialAvailable, expectedInitial);
+        const frames = session.bufferFrames;
+        const samples = new Int16Array(frames * session.channels);
+        assert.ok(session.enqueueSamples(samples, 0, frames));
+        assert.ok(freedCount >= 1, "fallback should notify freed buffers");
+        session.stop();
+    } finally {
+        restore();
+        Squeak.stopAudioOut();
+        Squeak.audioOutputManager = null;
+    }
+}
+
+async function testLegacyPipeline() {
+    const restore = installAudioEnvironment({ supportWorklet: false, immediateTimers: true });
+    try {
+        Squeak.stopAudioOut();
+        let freedCount = 0;
+        const session = Squeak.ensureAudioOutputSession({
+            bufferFrames: 64,
+            sampleRate: 16000,
+            channels: 2,
+            onBufferFreed() {
+                freedCount += 1;
+            },
+        });
+        assert.ok(session);
+        assert.strictEqual(session.type, "legacy");
+        const expectedInitial = 3 * session.bufferFrames * session.channels * 2;
+        assert.strictEqual(session.availableByteCount(), expectedInitial);
+        const samples = new Int16Array(session.bufferFrames * session.channels);
+        assert.ok(session.enqueueSamples(samples, 0, session.bufferFrames));
+        assert.ok(freedCount >= 1, "legacy session should release buffers asynchronously");
+        session.stop();
+    } finally {
+        restore();
+        Squeak.stopAudioOut();
+        Squeak.audioOutputManager = null;
+    }
+}
+
+await testWorkletPipeline();
+await testWorkletFallback();
+await testLegacyPipeline();

--- a/tests/storage/storage-quota.test.mjs
+++ b/tests/storage/storage-quota.test.mjs
@@ -1,0 +1,213 @@
+"use strict";
+
+import assert from "assert";
+import fs from "fs/promises";
+import vm from "vm";
+
+function createFakeCache() {
+    const store = new Map();
+    function getUrl(request) {
+        if (!request) return undefined;
+        if (typeof request === "string") return request;
+        if (request.url) return request.url;
+        return String(request);
+    }
+    return {
+        name: null,
+        async put(request, response) {
+            const url = getUrl(request);
+            const cloned = await cloneResponse(response);
+            store.set(url, cloned);
+        },
+        async match(request) {
+            const url = getUrl(request);
+            if (!store.has(url)) return undefined;
+            const entry = store.get(url);
+            return new Response(entry.buffer.slice(0), { headers: entry.headers });
+        },
+        async delete(request) {
+            const url = getUrl(request);
+            store.delete(url);
+        },
+        async keys() {
+            return Array.from(store.keys()).map((url) => new Request(url));
+        },
+    };
+}
+
+async function cloneResponse(response) {
+    const buffer = await response.arrayBuffer();
+    const headers = new Headers(response.headers);
+    return { buffer, headers };
+}
+
+function createFakeCaches() {
+    const caches = new Map();
+    return {
+        async open(name) {
+            if (!caches.has(name)) {
+                const cache = createFakeCache();
+                cache.name = name;
+                caches.set(name, cache);
+            }
+            return caches.get(name);
+        },
+    };
+}
+
+async function loadServiceWorker(fakeCaches, clientListeners) {
+    const handlers = {};
+    const swGlobal = {
+        caches: fakeCaches,
+        clients: {
+            matchAll: async () => [{
+                postMessage(payload) {
+                    clientListeners.forEach((listener) => {
+                        try { listener({ data: payload }); } catch (_) {}
+                    });
+                },
+            }],
+            claim: () => Promise.resolve(),
+        },
+        skipWaiting: () => Promise.resolve(),
+        addEventListener: (type, handler) => {
+            handlers[type] = handler;
+        },
+    };
+    const context = {
+        self: swGlobal,
+        caches: fakeCaches,
+        Response,
+        Request,
+        Headers,
+        ArrayBuffer,
+        Uint8Array,
+        console,
+    };
+    const source = await fs.readFile(new URL("../../run/squeak-storage-sw.js", import.meta.url), "utf8");
+    vm.runInNewContext(source, context, { filename: "squeak-storage-sw.js" });
+    return {
+        dispatchMessage(message) {
+            const handler = handlers.message;
+            if (!handler) return Promise.resolve();
+            const waiters = [];
+            handler({
+                data: message,
+                waitUntil(promise) { if (promise) waiters.push(promise); },
+            });
+            return Promise.all(waiters);
+        },
+    };
+}
+
+async function runStorageQuotaTest() {
+    const fakeCaches = createFakeCaches();
+    const clientListeners = [];
+    const serviceWorkerContext = await loadServiceWorker(fakeCaches, clientListeners);
+    const pendingMessages = [];
+    const fakeController = {
+        postMessage(message) {
+            const cloned = Object.assign({}, message);
+            pendingMessages.push(serviceWorkerContext.dispatchMessage(cloned));
+        },
+    };
+    const serviceWorkerRegistration = { scope: "./", active: fakeController };
+    const messageListeners = clientListeners;
+    const serviceWorker = {
+        controller: fakeController,
+        register: async () => serviceWorkerRegistration,
+        ready: Promise.resolve(serviceWorkerRegistration),
+        addEventListener: (type, handler) => {
+            if (type === "message") messageListeners.push(handler);
+        },
+    };
+    const quotas = { usage: 0, quota: 1024 * 1024 };
+    const signaled = [];
+    global.navigator = {
+        serviceWorker,
+        storage: {
+            estimate: async () => ({ usage: quotas.usage, quota: quotas.quota }),
+        },
+    };
+    global.caches = fakeCaches;
+    global.Squeak = {
+        StorageVFS: {},
+        StorageQuota: {},
+        vm: {
+            primHandler: {
+                signalSemaphoreWithIndex(index) {
+                    signaled.push(index);
+                },
+            },
+        },
+    };
+    global.Squeak.Settings = {};
+
+    const vfsModule = await import(new URL("../../vm.storage.vfs.js", import.meta.url).href);
+    const quotaModule = await import(new URL("../../vm.storage.quota.js", import.meta.url).href);
+
+    const {
+        ensureStorageVFSRegistration,
+        notifyStorageWrite,
+    } = vfsModule;
+    const {
+        ensureStorageQuotaMonitor,
+        forceStorageQuotaSample,
+        drainStorageQuotaEvents,
+        setStorageQuotaWarningSemaphore,
+        getStorageQuotaState,
+    } = quotaModule;
+
+    await ensureStorageVFSRegistration({ autoReplay: false });
+
+    ensureStorageQuotaMonitor({
+        thresholds: { notice: 0.3, warning: 0.6, critical: 0.8 },
+        pollInterval: 0,
+        autoSample: false,
+        immediate: false,
+    });
+
+    notifyStorageWrite("project.image", new Uint8Array([1, 2, 3, 4]).buffer, { size: 4, updatedAt: 1111 });
+    notifyStorageWrite("temp.log", new Uint8Array([5, 6, 7, 8, 9]).buffer, { size: 5, updatedAt: 2222 });
+
+    await Promise.all(pendingMessages.splice(0));
+
+    quotas.usage = 900000;
+    quotas.quota = 1000000;
+
+    setStorageQuotaWarningSemaphore(7);
+
+    const sample = await forceStorageQuotaSample();
+    await Promise.all(pendingMessages.splice(0));
+
+    assert.ok(sample.percentUsed >= 0.9);
+
+    const events = drainStorageQuotaEvents();
+    const levels = events.filter((event) => event.type === "threshold").map((event) => event.level);
+    assert.ok(levels.includes("notice"));
+    assert.ok(levels.includes("warning"));
+    assert.ok(levels.includes("critical"));
+
+    const evictionRequest = events.find((event) => event.type === "eviction-request");
+    assert.ok(evictionRequest, "expected eviction request event");
+    assert.ok(Array.isArray(evictionRequest.paths) && evictionRequest.paths.includes("temp.log"));
+
+    const evictionResult = events.find((event) => event.type === "eviction-result");
+    assert.ok(evictionResult, "expected eviction result event");
+    assert.ok(evictionResult.result && Array.isArray(evictionResult.result.paths));
+    assert.ok(evictionResult.result.paths.includes("temp.log"));
+
+    assert.strictEqual(signaled.includes(7), true);
+
+    const cache = await fakeCaches.open("squeak-vfs-cache");
+    const keys = await cache.keys();
+    assert.strictEqual(keys.some((request) => request.url.includes("temp.log")), false);
+    assert.strictEqual(keys.some((request) => request.url.includes("project.image")), true);
+
+    const state = getStorageQuotaState();
+    assert.ok(state.history.length >= 1);
+    assert.ok(state.lastEviction);
+}
+
+await runStorageQuotaTest();
+

--- a/tests/storage/storage-vfs.test.mjs
+++ b/tests/storage/storage-vfs.test.mjs
@@ -1,0 +1,178 @@
+"use strict";
+
+import assert from "assert";
+import fs from "fs/promises";
+import vm from "vm";
+
+function createFakeCache() {
+    const store = new Map();
+    function getUrl(request) {
+        if (!request) return undefined;
+        if (typeof request === "string") return request;
+        if (request.url) return request.url;
+        return String(request);
+    }
+    return {
+        name: null,
+        async put(request, response) {
+            const url = getUrl(request);
+            const cloned = await cloneResponse(response);
+            store.set(url, cloned);
+        },
+        async match(request) {
+            const url = getUrl(request);
+            if (!store.has(url)) return undefined;
+            const entry = store.get(url);
+            return new Response(entry.buffer.slice(0), { headers: entry.headers });
+        },
+        async delete(request) {
+            const url = getUrl(request);
+            store.delete(url);
+        },
+        async keys() {
+            return Array.from(store.keys()).map((url) => new Request(url));
+        },
+        _entries() {
+            return new Map(store);
+        },
+    };
+}
+
+async function cloneResponse(response) {
+    const buffer = await response.arrayBuffer();
+    const headers = new Headers(response.headers);
+    return { buffer, headers };
+}
+
+function createFakeCaches() {
+    const caches = new Map();
+    return {
+        async open(name) {
+            if (!caches.has(name)) {
+                const cache = createFakeCache();
+                cache.name = name;
+                caches.set(name, cache);
+            }
+            return caches.get(name);
+        },
+    };
+}
+
+async function loadServiceWorker(fakeCaches) {
+    const handlers = {};
+    const swGlobal = {
+        caches: fakeCaches,
+        clients: {
+            matchAll: async () => [],
+            claim: () => Promise.resolve(),
+        },
+        skipWaiting: () => Promise.resolve(),
+        addEventListener: (type, handler) => {
+            handlers[type] = handler;
+        },
+    };
+    const context = {
+        self: swGlobal,
+        caches: fakeCaches,
+        Response,
+        Request,
+        Headers,
+        ArrayBuffer,
+        Uint8Array,
+        console,
+    };
+    const source = await fs.readFile(new URL("../../run/squeak-storage-sw.js", import.meta.url), "utf8");
+    vm.runInNewContext(source, context, { filename: "squeak-storage-sw.js" });
+    return {
+        dispatchMessage(message) {
+            const handler = handlers.message;
+            if (!handler) return Promise.resolve();
+            const waiters = [];
+            handler({
+                data: message,
+                waitUntil(promise) { if (promise) waiters.push(promise); },
+            });
+            return Promise.all(waiters);
+        },
+    };
+}
+
+async function runStorageVFSTest() {
+    const fakeCaches = createFakeCaches();
+    const serviceWorkerContext = await loadServiceWorker(fakeCaches);
+    const pendingMessages = [];
+    const fakeController = {
+        postMessage(message) {
+            const cloned = Object.assign({}, message);
+            pendingMessages.push(serviceWorkerContext.dispatchMessage(cloned));
+        },
+    };
+    const serviceWorkerRegistration = { scope: "./", active: fakeController };
+    const serviceWorker = {
+        controller: fakeController,
+        register: async () => serviceWorkerRegistration,
+        ready: Promise.resolve(serviceWorkerRegistration),
+        addEventListener: () => {},
+    };
+    global.navigator = { serviceWorker };
+    global.caches = fakeCaches;
+    const writes = [];
+    global.Squeak = {
+        StorageVFS: {},
+        filePut(path, contents) {
+            const size = contents instanceof ArrayBuffer
+                ? contents.byteLength
+                : ArrayBuffer.isView(contents)
+                    ? contents.byteLength
+                    : 0;
+            writes.push({ path, size });
+        },
+    };
+    const moduleUrl = new URL("../../vm.storage.vfs.js", import.meta.url).href;
+    const {
+        ensureStorageVFSRegistration,
+        notifyStorageWrite,
+        notifyStorageDelete,
+        notifyStorageRename,
+        replayStorageFromCache,
+        getStorageVFSState,
+    } = await import(moduleUrl);
+
+    await ensureStorageVFSRegistration({ autoReplay: false });
+    const stateAfterRegistration = getStorageVFSState();
+    assert.strictEqual(stateAfterRegistration.supported, true);
+
+    notifyStorageWrite("project.changes", new Uint8Array([1, 2, 3, 4]).buffer, { size: 4, updatedAt: 1111 });
+    await Promise.all(pendingMessages.splice(0));
+
+    const cache = await fakeCaches.open("squeak-vfs-cache");
+    const writeKeys = await cache.keys();
+    assert.ok(writeKeys.some((request) => request.url.includes("project.changes")));
+
+    notifyStorageRename("project.changes", "project-new.changes", {
+        contents: new Uint8Array([9, 9]).buffer,
+        size: 2,
+        updatedAt: 2222,
+    });
+    await Promise.all(pendingMessages.splice(0));
+    const renameKeys = await cache.keys();
+    assert.ok(renameKeys.some((request) => request.url.includes("project-new.changes")));
+
+    notifyStorageDelete("project-new.changes", { updatedAt: 3333 });
+    await Promise.all(pendingMessages.splice(0));
+    const deleteKeys = await cache.keys();
+    assert.strictEqual(deleteKeys.some((request) => request.url.includes("project-new.changes")), false);
+
+    // Rehydrate via replay
+    notifyStorageWrite("persistent.log", new Uint8Array([7, 7, 7]).buffer, { size: 3, updatedAt: 4444 });
+    await Promise.all(pendingMessages.splice(0));
+    const replayResult = await replayStorageFromCache();
+    assert.strictEqual(replayResult.restored >= 1, true);
+    assert.strictEqual(writes.some((entry) => entry.path === "persistent.log"), true);
+
+    const finalState = getStorageVFSState();
+    assert.strictEqual(finalState.pending, 0);
+    assert.ok(finalState.lastOperationAt || finalState.sequence > 0);
+}
+
+await runStorageVFSTest();

--- a/tests/worker-input/channel.test.mjs
+++ b/tests/worker-input/channel.test.mjs
@@ -17,12 +17,14 @@ class FakeWorker {
     }
 }
 
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 function lastMessage(worker) {
     if (!worker.messages.length) return null;
     return worker.messages[worker.messages.length - 1];
 }
 
-function run() {
+async function run() {
     const controller = new WorkerVMController();
     const fakeWorker = new FakeWorker();
     controller.worker = fakeWorker;
@@ -35,13 +37,33 @@ function run() {
 
     controller.setClipboardText("hello");
     assert.strictEqual(controller._clipboardState.text, "hello");
+    const clipboardSeed = lastMessage(fakeWorker);
+    assert.strictEqual(clipboardSeed.type, "clipboard-set");
+    assert.strictEqual(typeof clipboardSeed.timestamp, "number");
+    fakeWorker.messages.length = 0;
 
     controller._handleMessage({ type: "clipboard-read-request", requestId: 42 });
-    assert.deepStrictEqual(lastMessage(fakeWorker), { type: "clipboard-read-response", requestId: 42, text: "hello" });
+    await tick();
+    const readResponse = lastMessage(fakeWorker);
+    assert.strictEqual(readResponse.type, "clipboard-read-response");
+    assert.strictEqual(readResponse.requestId, 42);
+    assert.strictEqual(readResponse.text, "hello");
+    assert.strictEqual(readResponse.fromCache, true);
+    assert.strictEqual(typeof readResponse.cachedAt, "number");
 
     controller._handleMessage({ type: "clipboard-write-request", requestId: 43, text: "world" });
-    assert.deepStrictEqual(lastMessage(fakeWorker), { type: "clipboard-write-response", requestId: 43, text: "world" });
+    await tick();
+    const writeResponse = lastMessage(fakeWorker);
+    assert.strictEqual(writeResponse.type, "clipboard-write-response");
+    assert.strictEqual(writeResponse.requestId, 43);
+    assert.strictEqual(writeResponse.text, "world");
+    assert.strictEqual(writeResponse.fromCache, true);
     assert.strictEqual(controller._clipboardState.text, "world");
+
+    const diagnostics = controller.getClipboardDiagnostics();
+    assert.strictEqual(diagnostics.text, "world");
+    assert.strictEqual(typeof diagnostics.cachedAt, "number");
+    assert.strictEqual(diagnostics.queuePending, 0);
 
     const reportPromise = controller.requestFeatureReport();
     const reportRequest = lastMessage(fakeWorker);
@@ -59,12 +81,11 @@ function run() {
         },
     });
 
-    return reportPromise.then((payload) => {
-        assert.ok(payload.report);
-        assert.strictEqual(controller.lastFeatureReport, payload.report);
-        controller.terminate();
-        assert.strictEqual(fakeWorker.terminated, true);
-    });
+    const payload = await reportPromise;
+    assert.ok(payload.report);
+    assert.strictEqual(controller.lastFeatureReport, payload.report);
+    controller.terminate();
+    assert.strictEqual(fakeWorker.terminated, true);
 }
 
 await run();

--- a/tests/worker-input/clipboard-permissions.test.mjs
+++ b/tests/worker-input/clipboard-permissions.test.mjs
@@ -1,0 +1,88 @@
+"use strict";
+
+import assert from "assert";
+import { WorkerVMController } from "../../vm.worker.host.js";
+
+class FakeWorker {
+    constructor() {
+        this.messages = [];
+    }
+
+    postMessage(payload) {
+        this.messages.push(payload);
+    }
+}
+
+class FakePermissionStatus {
+    constructor(state) {
+        this.state = state;
+    }
+
+    addEventListener() {}
+}
+
+function createDeniedNavigator() {
+    return {
+        clipboard: {
+            readText: () => Promise.reject(new Error("Permission denied")),
+            writeText: () => Promise.reject(new Error("Permission denied")),
+        },
+        permissions: {
+            query: ({ name }) => {
+                if (name === "clipboard-read" || name === "clipboard-write") {
+                    return Promise.resolve(new FakePermissionStatus("denied"));
+                }
+                return Promise.resolve(new FakePermissionStatus("granted"));
+            },
+        },
+    };
+}
+
+function lastMessage(worker) {
+    if (!worker.messages.length) return null;
+    return worker.messages[worker.messages.length - 1];
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function runDeniedScenario() {
+    const originalNavigator = global.navigator;
+    global.navigator = createDeniedNavigator();
+
+    const controller = new WorkerVMController();
+    const fakeWorker = new FakeWorker();
+    controller.worker = fakeWorker;
+
+    controller.setClipboardText("cached");
+    controller._handleMessage({ type: "clipboard-read-request", requestId: 7 });
+    await tick();
+    const readResponse = lastMessage(fakeWorker);
+    assert.strictEqual(readResponse.type, "clipboard-read-response");
+    assert.strictEqual(readResponse.permission, "denied");
+    assert.strictEqual(readResponse.text, "cached");
+    assert.strictEqual(readResponse.fromCache, true);
+    assert.ok(readResponse.error);
+    assert.strictEqual(readResponse.error.name, "ClipboardPermissionDenied");
+    assert.strictEqual(controller._clipboardState.lastStatus.type, "permission-denied");
+
+    controller._handleMessage({ type: "clipboard-write-request", requestId: 8, text: "outbound" });
+    await tick();
+    const writeResponse = lastMessage(fakeWorker);
+    assert.strictEqual(writeResponse.type, "clipboard-write-response");
+    assert.strictEqual(writeResponse.permission, "denied");
+    assert.strictEqual(writeResponse.text, "outbound");
+    assert.strictEqual(writeResponse.fromCache, true);
+    assert.ok(writeResponse.error);
+    assert.strictEqual(writeResponse.error.name, "ClipboardPermissionDenied");
+    assert.strictEqual(controller._clipboardState.text, "outbound");
+
+    const diagnostics = controller.getClipboardDiagnostics();
+    assert.strictEqual(diagnostics.permissions.read, "denied");
+    assert.strictEqual(diagnostics.permissions.write, "denied");
+    assert.ok(diagnostics.errorCounts.ClipboardPermissionDenied >= 2);
+
+    if (originalNavigator === undefined) delete global.navigator;
+    else global.navigator = originalNavigator;
+}
+
+await runDeniedScenario();

--- a/tests/worker-input/clipboard-queue.test.mjs
+++ b/tests/worker-input/clipboard-queue.test.mjs
@@ -1,0 +1,129 @@
+"use strict";
+
+import assert from "assert";
+import { WorkerVMController } from "../../vm.worker.host.js";
+
+class FakeWorker {
+    constructor() {
+        this.messages = [];
+    }
+
+    postMessage(payload) {
+        this.messages.push(payload);
+    }
+}
+
+class FakePermissionStatus {
+    constructor(state) {
+        this.state = state;
+    }
+
+    addEventListener() {}
+}
+
+function setupNavigator(log) {
+    let readCount = 0;
+    let writeCount = 0;
+    const readResolvers = [];
+    const writeResolvers = [];
+    const navigatorStub = {
+        clipboard: {
+            readText: () => {
+                const index = ++readCount;
+                log.push({ type: "read-start", index });
+                return new Promise((resolve) => {
+                    readResolvers.push(() => {
+                        log.push({ type: "read-resolve", index });
+                        resolve("value-" + index);
+                    });
+                });
+            },
+            writeText: (text) => {
+                const index = ++writeCount;
+                log.push({ type: "write-start", text, index });
+                return new Promise((resolve) => {
+                    writeResolvers.push(() => {
+                        log.push({ type: "write-resolve", text, index });
+                        resolve();
+                    });
+                });
+            },
+        },
+        permissions: {
+            query: ({ name }) => {
+                if (name === "clipboard-read" || name === "clipboard-write") {
+                    return Promise.resolve(new FakePermissionStatus("granted"));
+                }
+                return Promise.resolve(new FakePermissionStatus("granted"));
+            },
+        },
+    };
+    return { navigator: navigatorStub, readResolvers, writeResolvers, log };
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function runQueueScenario() {
+    const log = [];
+    const { navigator, readResolvers, writeResolvers } = setupNavigator(log);
+    const originalNavigator = global.navigator;
+    try {
+        global.navigator = navigator;
+
+        const controller = new WorkerVMController();
+        const fakeWorker = new FakeWorker();
+        controller.worker = fakeWorker;
+
+        controller._handleMessage({ type: "clipboard-read-request", requestId: 1 });
+        await tick();
+        assert.strictEqual(readResolvers.length, 1, "first read should start after scheduling");
+
+        controller._handleMessage({ type: "clipboard-read-request", requestId: 2 });
+        await tick();
+        assert.strictEqual(readResolvers.length, 1, "second read should wait until first completes");
+
+        readResolvers.shift()();
+        await tick();
+        assert.strictEqual(readResolvers.length, 1, "second read should start after first resolves");
+
+        readResolvers.shift()();
+        await tick();
+
+        assert.strictEqual(fakeWorker.messages.length, 2);
+        assert.strictEqual(fakeWorker.messages[0].requestId, 1);
+        assert.strictEqual(fakeWorker.messages[0].text, "value-1");
+        assert.strictEqual(fakeWorker.messages[1].requestId, 2);
+        assert.strictEqual(fakeWorker.messages[1].text, "value-2");
+
+        fakeWorker.messages.length = 0;
+
+        controller._handleMessage({ type: "clipboard-write-request", requestId: 3, text: "alpha" });
+        await tick();
+        assert.strictEqual(writeResolvers.length, 1, "first write should start after scheduling");
+
+        controller._handleMessage({ type: "clipboard-write-request", requestId: 4, text: "beta" });
+        await tick();
+        assert.strictEqual(writeResolvers.length, 1, "second write should queue behind first");
+
+        writeResolvers.shift()();
+        await tick();
+        assert.strictEqual(writeResolvers.length, 1, "second write should start after first resolves");
+
+        writeResolvers.shift()();
+        await tick();
+
+        assert.strictEqual(fakeWorker.messages.length, 2);
+        assert.strictEqual(fakeWorker.messages[0].requestId, 3);
+        assert.strictEqual(fakeWorker.messages[0].text, "alpha");
+        assert.strictEqual(fakeWorker.messages[1].requestId, 4);
+        assert.strictEqual(fakeWorker.messages[1].text, "beta");
+
+        const queueState = controller._clipboardQueue.getState();
+        assert.strictEqual(queueState.pending, 0);
+    } finally {
+        if (originalNavigator === undefined) delete global.navigator;
+        else global.navigator = originalNavigator;
+    }
+}
+
+await runQueueScenario();

--- a/tests/worker-input/clipboard-state.test.mjs
+++ b/tests/worker-input/clipboard-state.test.mjs
@@ -1,0 +1,28 @@
+"use strict";
+
+import assert from "assert";
+import { WorkerVMController } from "../../vm.worker.host.js";
+
+async function runStateDiagnosticsScenario() {
+    const controller = new WorkerVMController();
+    controller.worker = { postMessage() {} };
+
+    controller.setClipboardText("baseline", { timestamp: 2000 });
+    assert.strictEqual(controller._clipboardState.text, "baseline");
+    assert.strictEqual(controller._clipboardState.cachedAt, 2000);
+
+    controller.setClipboardText("stale", { timestamp: 1500 });
+    assert.strictEqual(controller._clipboardState.text, "baseline");
+    assert.ok(controller._clipboardState.staleDrops >= 1);
+
+    controller._handleMessage({ type: "clipboard-set", text: "worker", timestamp: 3000, changed: true });
+    assert.strictEqual(controller._clipboardState.text, "worker");
+    assert.strictEqual(controller._clipboardState.cachedAt, 3000);
+
+    const diagnostics = controller.getClipboardDiagnostics();
+    assert.strictEqual(diagnostics.text, "worker");
+    assert.strictEqual(diagnostics.staleDrops, controller._clipboardState.staleDrops);
+    assert.strictEqual(diagnostics.queuePending, 0);
+}
+
+await runStateDiagnosticsScenario();

--- a/vm.audio.browser.js
+++ b/vm.audio.browser.js
@@ -21,41 +21,946 @@
  * THE SOFTWARE.
  */
 
-Object.extend(Squeak,
-"audio", {
-    startAudioOut: function() {
-        if (!this.audioOutContext) {
-            this.audioOutContext = new AudioContext();
-        }
-        return this.audioOutContext;
-    },
-    stopAudioOut: function() {
-        if (this.audioOutContext) {
-            this.audioOutContext.close();
-            this.audioOutContext = null;
-        }
-    },
-    startAudioIn: function(thenDo, errorDo) {
-        if (this.audioInContext) {
-            this.audioInSource.disconnect();
-            return thenDo(this.audioInContext, this.audioInSource);
-        }
-        if (!navigator.mediaDevices) return errorDo("test: audio input not supported");
-        navigator.mediaDevices.getUserMedia({audio: true})
-            .then(stream => {
-                this.audioInContext = new AudioContext();
-                this.audioInSource = this.audioInContext.createMediaStreamSource(stream);
-                thenDo(this.audioInContext, this.audioInSource);
-            })
-            .catch(err => errorDo("cannot access microphone. " + err.name + ": " + err.message));
-    },
-    stopAudioIn: function() {
-        if (this.audioInSource) {
-            this.audioInSource.disconnect();
-            this.audioInSource = null;
-            this.audioInContext.close();
-            this.audioInContext = null;
+(function bootstrapAudioBridge(global) {
+    var SqueakGlobal = global.Squeak || (global.Squeak = {});
+    var READ_INDEX = 0;
+    var WRITE_INDEX = 1;
+    var DEFAULT_NOTIFY_FRAMES = 128;
+
+    function hasSharedArrayBuffer(globalScope) {
+        return typeof globalScope.SharedArrayBuffer === "function"
+            && typeof globalScope.Atomics === "object"
+            && globalScope.Atomics !== null
+            && (globalScope.crossOriginIsolated !== false);
+    }
+
+    function createWorkletSource() {
+        return `
+            const READ_INDEX = ${READ_INDEX};
+            const WRITE_INDEX = ${WRITE_INDEX};
+
+            class SqueakAudioWorkletProcessor extends AudioWorkletProcessor {
+                constructor() {
+                    super();
+                    this.channelCount = 1;
+                    this.capacity = 0;
+                    this.buffer = null;
+                    this.state = null;
+                    this.notifyInterval = ${DEFAULT_NOTIFY_FRAMES};
+                    this.consumedSinceNotify = 0;
+                    this.underrunSinceNotify = 0;
+                    this.port.onmessage = (event) => {
+                        const data = event.data || {};
+                        if (data.type === "configure") {
+                            this.channelCount = data.channels || 1;
+                            this.capacity = data.capacity | 0;
+                            this.buffer = data.samples || null;
+                            this.state = data.state || null;
+                            this.notifyInterval = data.notifyInterval || ${DEFAULT_NOTIFY_FRAMES};
+                            this.consumedSinceNotify = 0;
+                            this.underrunSinceNotify = 0;
+                        }
+                    };
+                }
+
+                process(_inputs, outputs) {
+                    const output = outputs[0];
+                    if (!output) return true;
+                    const frames = output[0] ? output[0].length : 0;
+                    if (!this.buffer || !this.state || !frames) {
+                        for (let ch = 0; ch < output.length; ch++) {
+                            output[ch].fill(0);
+                        }
+                        return true;
+                    }
+                    const channels = this.channelCount;
+                    const capacity = this.capacity;
+                    let readIndex = Atomics.load(this.state, READ_INDEX) | 0;
+                    const writeIndex = Atomics.load(this.state, WRITE_INDEX) | 0;
+                    let available = writeIndex >= readIndex
+                        ? writeIndex - readIndex
+                        : (capacity - readIndex) + writeIndex;
+                    for (let frame = 0; frame < frames; frame++) {
+                        const frameBase = (readIndex * channels) % (capacity * channels);
+                        if (available <= 0) {
+                            for (let ch = 0; ch < output.length; ch++) {
+                                output[ch][frame] = 0;
+                            }
+                            this.underrunSinceNotify++;
+                        } else {
+                            for (let ch = 0; ch < output.length; ch++) {
+                                const sourceChannel = ch < channels ? ch : channels - 1;
+                                output[ch][frame] = this.buffer[frameBase + sourceChannel] || 0;
+                            }
+                            readIndex = (readIndex + 1) % capacity;
+                            available--;
+                            this.consumedSinceNotify++;
+                        }
+                    }
+                    Atomics.store(this.state, READ_INDEX, readIndex);
+                    if (this.consumedSinceNotify >= this.notifyInterval) {
+                        this.port.postMessage({ type: "freed", frames: this.consumedSinceNotify });
+                        this.consumedSinceNotify = 0;
+                    }
+                    if (this.underrunSinceNotify >= this.notifyInterval) {
+                        this.port.postMessage({ type: "underrun", frames: this.underrunSinceNotify });
+                        this.underrunSinceNotify = 0;
+                    }
+                    return true;
+                }
+            }
+
+            registerProcessor("squeak-audio-worklet", SqueakAudioWorkletProcessor);
+        `;
+    }
+
+    function clampChannels(channelCount, fallback) {
+        if (!channelCount || channelCount < 1) return fallback;
+        return Math.max(1, Math.min(channelCount, 2));
+    }
+
+    class AudioOutputManager {
+        constructor(globalScope) {
+            this.global = globalScope;
+            this.context = null;
+            this.session = null;
+            this.workletModulePromise = null;
+            this.supportsWorklet = false;
+            this._detectSupport();
         }
 
-    },
-});
+        _detectSupport() {
+            var globalScope = this.global;
+            var AudioCtx = globalScope.AudioContext || globalScope.webkitAudioContext;
+            if (!AudioCtx) return;
+            try {
+                var context = new AudioCtx({ latencyHint: "interactive" });
+                this.supportsWorklet = !!(context.audioWorklet && globalScope.AudioWorkletNode && hasSharedArrayBuffer(globalScope));
+                context.close();
+            } catch (err) {
+                this.supportsWorklet = false;
+            }
+        }
+
+        ensureContext() {
+            if (this.context) return this.context;
+            var AudioCtx = this.global.AudioContext || this.global.webkitAudioContext;
+            if (!AudioCtx) return null;
+            this.context = new AudioCtx({ latencyHint: "interactive" });
+            return this.context;
+        }
+
+        _ensureWorkletModulePromise() {
+            if (!this.context || !this.supportsWorklet) {
+                return Promise.reject(new Error("worklet unsupported"));
+            }
+            if (!this.workletModulePromise) {
+                var source = createWorkletSource();
+                var blob = new this.global.Blob([source], { type: "application/javascript" });
+                var url = this.global.URL.createObjectURL(blob);
+                this.workletModulePromise = this.context.audioWorklet.addModule(url).finally(() => {
+                    this.global.URL.revokeObjectURL(url);
+                });
+            }
+            return this.workletModulePromise;
+        }
+
+        ensureSession(options) {
+            var context = this.ensureContext();
+            if (!context) return null;
+            if (this.session) {
+                this.session.stop();
+                this.session = null;
+            }
+            if (context.state === "suspended" && typeof context.resume === "function") {
+                context.resume().catch(function() {});
+            }
+            if (this.supportsWorklet) {
+                var modulePromise = this._ensureWorkletModulePromise().catch((err) => {
+                    this.supportsWorklet = false;
+                    throw err;
+                });
+                this.session = new AudioOutputWorkletSession(this.global, context, options, modulePromise);
+            } else {
+                this.session = new AudioOutputLegacySession(this.global, context, options);
+            }
+            this.session.prepare();
+            return this.session;
+        }
+
+        currentSession() {
+            return this.session || null;
+        }
+
+        stop() {
+            if (this.session) {
+                this.session.stop();
+                this.session = null;
+            }
+            if (this.context) {
+                if (typeof this.context.close === "function") {
+                    this.context.close();
+                }
+                this.context = null;
+            }
+        }
+
+        diagnostics() {
+            return {
+                hasContext: !!this.context,
+                sessionType: this.session ? this.session.type : null,
+                supportsWorklet: this.supportsWorklet,
+            };
+        }
+    }
+
+    class AudioOutputWorkletSession {
+        constructor(globalScope, context, options, modulePromise) {
+            this.global = globalScope;
+            this.context = context;
+            this.type = "worklet";
+            this.channels = clampChannels(options && options.channels, 2);
+            this.sampleRate = options && options.sampleRate || context.sampleRate || 44100;
+            this.bufferFrames = options && options.bufferFrames || 2048;
+            this.notifyInterval = options && options.notifyInterval || DEFAULT_NOTIFY_FRAMES;
+            this.onBufferFreed = options && options.onBufferFreed || null;
+            this.capacityFrames = Math.max(this.bufferFrames * 4, this.notifyInterval * 4);
+            this.samples = new Float32Array(new this.global.SharedArrayBuffer(Float32Array.BYTES_PER_ELEMENT * this.capacityFrames * this.channels));
+            this.state = new Int32Array(new this.global.SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2));
+            this.writeIndex = 0;
+            this.node = null;
+            this.readyPromise = null;
+            this.pendingFreedFrames = 0;
+            this.modulePromise = modulePromise || Promise.resolve();
+            this.fallbackSession = null;
+            this.atomics = this.global.Atomics || Atomics;
+            this.state[READ_INDEX] = 0;
+            this.state[WRITE_INDEX] = 0;
+        }
+
+        prepare() {
+            if (this.readyPromise) return this.readyPromise;
+            var session = this;
+            this.readyPromise = this.modulePromise.then(function() {
+                session.node = new session.global.AudioWorkletNode(session.context, "squeak-audio-worklet", {
+                    numberOfInputs: 0,
+                    numberOfOutputs: 1,
+                    outputChannelCount: [session.channels],
+                });
+                session.node.port.onmessage = function(event) {
+                    session._handleWorkletMessage(event.data || {});
+                };
+                session.node.connect(session.context.destination);
+                session.node.port.postMessage({
+                    type: "configure",
+                    channels: session.channels,
+                    capacity: session.capacityFrames,
+                    samples: session.samples,
+                    state: session.state,
+                    notifyInterval: session.notifyInterval,
+                });
+            }).catch(function(err) {
+                if (session.global.console && session.global.console.warn) {
+                    session.global.console.warn("Falling back to legacy audio output", err);
+                }
+                session.fallbackSession = new AudioOutputLegacySession(session.global, session.context, {
+                    channels: session.channels,
+                    sampleRate: session.sampleRate,
+                    bufferFrames: session.bufferFrames,
+                    onBufferFreed: session.onBufferFreed,
+                });
+                session.fallbackSession.prepare();
+            });
+            return this.readyPromise;
+        }
+
+        availableByteCount() {
+            if (this.fallbackSession) return this.fallbackSession.availableByteCount();
+            if (!this.state) return 0;
+            var readIndex = this.atomics.load(this.state, READ_INDEX);
+            var writeIndex = this.writeIndex;
+            var capacity = this.capacityFrames;
+            var freeFrames = readIndex > writeIndex
+                ? (readIndex - writeIndex - 1)
+                : (capacity - writeIndex + readIndex - 1);
+            if (freeFrames < 0) freeFrames = 0;
+            return freeFrames * this.channels * 2;
+        }
+
+        enqueueSamples(int16Array, startIndex, frameCount) {
+            if (this.fallbackSession) {
+                return this.fallbackSession.enqueueSamples(int16Array, startIndex, frameCount);
+            }
+            if (!this.samples || !this.state) return false;
+            var bytesAvailable = this.availableByteCount();
+            var requiredBytes = frameCount * this.channels * 2;
+            if (requiredBytes > bytesAvailable) return false;
+            var writeIndex = this.writeIndex;
+            var capacity = this.capacityFrames;
+            for (var frame = 0; frame < frameCount; frame++) {
+                var base = ((writeIndex % capacity) * this.channels);
+                for (var channel = 0; channel < this.channels; channel++) {
+                    var sampleIndex = startIndex + frame * this.channels + channel;
+                    this.samples[base + channel] = (int16Array[sampleIndex] || 0) / 32768;
+                }
+                writeIndex = (writeIndex + 1) % capacity;
+            }
+            this.writeIndex = writeIndex;
+            this.atomics.store(this.state, WRITE_INDEX, writeIndex);
+            return true;
+        }
+
+        enqueueSilence(frameCount) {
+            if (this.fallbackSession) {
+                return this.fallbackSession.enqueueSilence(frameCount);
+            }
+            if (!this.samples || !this.state) return false;
+            var bytesAvailable = this.availableByteCount();
+            var requiredBytes = frameCount * this.channels * 2;
+            if (requiredBytes > bytesAvailable) return false;
+            var writeIndex = this.writeIndex;
+            var capacity = this.capacityFrames;
+            for (var frame = 0; frame < frameCount; frame++) {
+                var base = ((writeIndex % capacity) * this.channels);
+                for (var channel = 0; channel < this.channels; channel++) {
+                    this.samples[base + channel] = 0;
+                }
+                writeIndex = (writeIndex + 1) % capacity;
+            }
+            this.writeIndex = writeIndex;
+            this.atomics.store(this.state, WRITE_INDEX, writeIndex);
+            return true;
+        }
+
+        _handleWorkletMessage(message) {
+            if (this.fallbackSession) {
+                return;
+            }
+            if (message.type === "freed" && message.frames) {
+                this.pendingFreedFrames += message.frames | 0;
+                this._drainFreedNotifications();
+            } else if (message.type === "underrun" && message.frames) {
+                if (this.global && this.global.console && this.global.console.warn) {
+                    this.global.console.warn("Squeak audio underrun", message.frames);
+                }
+            }
+        }
+
+        _drainFreedNotifications() {
+            if (!this.onBufferFreed) return;
+            while (this.pendingFreedFrames >= this.bufferFrames) {
+                this.pendingFreedFrames -= this.bufferFrames;
+                this.onBufferFreed();
+            }
+        }
+
+        stop() {
+            if (this.fallbackSession) {
+                this.fallbackSession.stop();
+                this.fallbackSession = null;
+                return;
+            }
+            if (this.node) {
+                try { this.node.disconnect(); } catch (e) { }
+                this.node.port.onmessage = null;
+                if (typeof this.node.port.postMessage === "function") {
+                    this.node.port.postMessage({ type: "configure", channels: this.channels, capacity: 0 });
+                }
+                this.node = null;
+            }
+            this.samples = null;
+            this.state = null;
+            this.writeIndex = 0;
+            this.pendingFreedFrames = 0;
+        }
+    }
+
+    class AudioOutputLegacySession {
+        constructor(globalScope, context, options) {
+            this.global = globalScope;
+            this.context = context;
+            this.type = "legacy";
+            this.channels = clampChannels(options && options.channels, 2);
+            this.sampleRate = options && options.sampleRate || context.sampleRate || 44100;
+            this.bufferFrames = options && options.bufferFrames || 2048;
+            this.onBufferFreed = options && options.onBufferFreed || null;
+            this.buffersReady = [];
+            this.buffersUnused = [];
+            this.nextTimeSlot = 0;
+            this._prepareBuffers();
+        }
+
+        async prepare() {
+            return Promise.resolve();
+        }
+
+        _prepareBuffers() {
+            this.buffersUnused = [
+                this.context.createBuffer(this.channels, this.bufferFrames, this.sampleRate),
+                this.context.createBuffer(this.channels, this.bufferFrames, this.sampleRate),
+                this.context.createBuffer(this.channels, this.bufferFrames, this.sampleRate),
+            ];
+        }
+
+        availableByteCount() {
+            if (!this.buffersUnused || !this.buffersUnused.length) return 0;
+            var availableFrames = this.buffersUnused.length * this.bufferFrames;
+            return availableFrames * this.channels * 2;
+        }
+
+        enqueueSamples(int16Array, startIndex, frameCount) {
+            if (!this.buffersUnused || !this.buffersUnused.length) return false;
+            var buffer = this.buffersUnused.shift();
+            var channels = Math.min(buffer.numberOfChannels || this.channels, this.channels);
+            for (var channel = 0; channel < channels; channel++) {
+                var jsSamples = buffer.getChannelData(channel);
+                var index = startIndex + channel;
+                for (var frame = 0; frame < frameCount; frame++) {
+                    jsSamples[frame] = (int16Array[index] || 0) / 32768;
+                    index += this.channels;
+                }
+                for (var pad = frameCount; pad < buffer.length; pad++) {
+                    jsSamples[pad] = 0;
+                }
+            }
+            for (var fill = channels; fill < buffer.numberOfChannels; fill++) {
+                buffer.getChannelData(fill).fill(0);
+            }
+            this.buffersReady.push(buffer);
+            this._schedulePlayback();
+            return true;
+        }
+
+        enqueueSilence(frameCount) {
+            if (!this.buffersUnused || !this.buffersUnused.length) return false;
+            var buffer = this.buffersUnused.shift();
+            var length = buffer.length;
+            for (var channel = 0; channel < buffer.numberOfChannels; channel++) {
+                var jsSamples = buffer.getChannelData(channel);
+                for (var frame = 0; frame < length; frame++) {
+                    jsSamples[frame] = 0;
+                }
+            }
+            this.buffersReady.push(buffer);
+            this._schedulePlayback();
+            return true;
+        }
+
+        _schedulePlayback() {
+            if (!this.context || !this.buffersReady || !this.buffersReady.length) return;
+            var source = this.context.createBufferSource();
+            source.buffer = this.buffersReady.shift();
+            source.connect(this.context.destination);
+            if (this.nextTimeSlot < this.context.currentTime) {
+                this.nextTimeSlot = this.context.currentTime;
+            }
+            source.start(this.nextTimeSlot);
+            var duration = source.buffer.duration || (source.buffer.length / this.sampleRate);
+            this.nextTimeSlot += duration;
+            var self = this;
+            this.global.setTimeout(function() {
+                if (!self.context) return;
+                self.buffersUnused.push(source.buffer);
+                if (self.onBufferFreed) self.onBufferFreed();
+            }, Math.max(0, (self.nextTimeSlot - self.context.currentTime) * 1000));
+            this._schedulePlayback();
+        }
+
+        stop() {
+            this.buffersReady = [];
+            this.buffersUnused = [];
+            this.nextTimeSlot = 0;
+        }
+    }
+
+    class MicrophoneAudioInputSession {
+        constructor(globalScope, context, source, stream) {
+            this.global = globalScope;
+            this.context = context;
+            this.source = source;
+            this.stream = stream;
+        }
+
+        connectProcessor(node) {
+            if (!this.source || !node || typeof this.source.connect !== "function") return;
+            this.source.connect(node);
+        }
+
+        stop() {
+            if (this.source && typeof this.source.disconnect === "function") {
+                this.source.disconnect();
+            }
+            if (this.stream && typeof this.stream.getTracks === "function") {
+                var tracks = this.stream.getTracks();
+                for (var i = 0; i < tracks.length; i++) {
+                    if (tracks[i] && typeof tracks[i].stop === "function") {
+                        tracks[i].stop();
+                    }
+                }
+            }
+            this.source = null;
+            this.stream = null;
+        }
+
+        diagnostics() {
+            return { mode: "microphone" };
+        }
+    }
+
+    function createSyntheticEvent(channels, frames, generator) {
+        var channelData = new Array(channels);
+        for (var ch = 0; ch < channels; ch++) {
+            channelData[ch] = generator(ch);
+        }
+        return {
+            inputBuffer: {
+                numberOfChannels: channels,
+                length: frames,
+                getChannelData: function(channel) {
+                    return channelData[channel];
+                },
+            },
+        };
+    }
+
+    class SyntheticAudioInputSession {
+        constructor(globalScope, context, options) {
+            this.global = globalScope;
+            this.context = context;
+            this.channels = clampChannels(options.channels || 1, 1);
+            var frequency = typeof options.frequency === "number" ? options.frequency : 440;
+            if (!isFinite(frequency) || frequency <= 0) frequency = 440;
+            this.frequency = frequency;
+            var amplitude = typeof options.amplitude === "number" ? Math.abs(options.amplitude) : 0.25;
+            if (!isFinite(amplitude)) amplitude = 0.25;
+            this.amplitude = Math.min(Math.max(amplitude, 0), 1);
+            this.phase = 0;
+            this.processor = null;
+            this.timerHandle = null;
+            this.blockFrames = options.blockFrames || 512;
+        }
+
+        _schedule() {
+            var self = this;
+            var intervalMs = (this.blockFrames / (this.context ? this.context.sampleRate || 44100 : 44100)) * 1000;
+            intervalMs = Math.max(10, Math.min(intervalMs, 200));
+            if (this.timerHandle !== null) return;
+            if (typeof this.global.setInterval === "function") {
+                this.timerHandle = this.global.setInterval(function() {
+                    self._emit();
+                }, intervalMs);
+                this._clearFn = function(handle) {
+                    if (typeof self.global.clearInterval === "function") {
+                        self.global.clearInterval(handle);
+                    }
+                };
+            } else if (typeof this.global.setTimeout === "function") {
+                (function loop() {
+                    self.timerHandle = self.global.setTimeout(function() {
+                        self._emit();
+                        loop();
+                    }, intervalMs);
+                })();
+                this._clearFn = function(handle) {
+                    if (typeof self.global.clearTimeout === "function") {
+                        self.global.clearTimeout(handle);
+                    }
+                };
+            }
+        }
+
+        _emit() {
+            if (!this.processor || typeof this.processor.onaudioprocess !== "function") return;
+            var frames = this.processor.bufferSize || this.blockFrames;
+            if (!frames || frames < 1) frames = this.blockFrames;
+            var sampleRate = this.context ? this.context.sampleRate || 44100 : 44100;
+            var angularIncrement = 2 * Math.PI * this.frequency / sampleRate;
+            var event = createSyntheticEvent(this.channels, frames, function(channel) {
+                var samples = new Float32Array(frames);
+                for (var i = 0; i < frames; i++) {
+                    samples[i] = Math.sin(this.phase + (angularIncrement * i)) * this.amplitude;
+                }
+                return samples;
+            }.bind(this));
+            this.phase += angularIncrement * frames;
+            this.phase = this.phase % (2 * Math.PI);
+            try {
+                this.processor.onaudioprocess(event);
+            } catch (err) {
+                console.warn("synthetic audio emit failed", err);
+            }
+        }
+
+        connectProcessor(node) {
+            this.processor = node || null;
+            if (!this.processor) return;
+            this._emit();
+            this._schedule();
+        }
+
+        stop() {
+            if (this.timerHandle !== null && this._clearFn) {
+                this._clearFn(this.timerHandle);
+            }
+            this.timerHandle = null;
+            this.processor = null;
+        }
+
+        diagnostics() {
+            return {
+                mode: "synthetic",
+                frequency: this.frequency,
+                amplitude: this.amplitude,
+                blockFrames: this.blockFrames,
+            };
+        }
+    }
+
+    class FileAudioInputSession {
+        constructor(globalScope, context, entry, options) {
+            this.global = globalScope;
+            this.context = context;
+            this.entry = entry;
+            this.channels = clampChannels(options.channels || entry.channels || 1, entry.channels || 1);
+            this.blockFrames = options.blockFrames || 512;
+            this.loop = typeof options.loop === "boolean" ? options.loop : (entry.loop !== undefined ? !!entry.loop : true);
+            this.position = 0;
+            this.processor = null;
+            this.timerHandle = null;
+        }
+
+        _emit() {
+            if (!this.processor || typeof this.processor.onaudioprocess !== "function") return;
+            var frames = this.processor.bufferSize || this.blockFrames;
+            if (!frames || frames < 1) frames = this.blockFrames;
+            var channelCount = this.channels;
+            var entry = this.entry;
+            var totalFrames = entry.channels ? (entry.samples.length / entry.channels) : 0;
+            if (!totalFrames || !isFinite(totalFrames)) {
+                var silent = createSyntheticEvent(channelCount, frames, function() {
+                    return new Float32Array(frames);
+                });
+                try {
+                    this.processor.onaudioprocess(silent);
+                } catch (err) {
+                    console.warn("file audio emit failed", err);
+                }
+                return;
+            }
+            var event = createSyntheticEvent(channelCount, frames, function(channel) {
+                var samples = new Float32Array(frames);
+                var srcChannel = channel < entry.channels ? channel : entry.channels - 1;
+                for (var i = 0; i < frames; i++) {
+                    if (!this.loop && this.position >= totalFrames) {
+                        samples[i] = 0;
+                        continue;
+                    }
+                    var frameIndex = (this.position + i) % totalFrames;
+                    var sourceIndex = (frameIndex * entry.channels) + srcChannel;
+                    samples[i] = entry.samples[sourceIndex] || 0;
+                }
+                return samples;
+            }.bind(this));
+            if (this.loop) {
+                this.position = (this.position + frames) % totalFrames;
+            } else {
+                this.position = Math.min(this.position + frames, totalFrames);
+            }
+            try {
+                this.processor.onaudioprocess(event);
+            } catch (err) {
+                console.warn("file audio emit failed", err);
+            }
+        }
+
+        _schedule() {
+            var self = this;
+            if (this.timerHandle !== null) return;
+            var sampleRate = this.context ? this.context.sampleRate || this.entry.sampleRate || 44100 : (this.entry.sampleRate || 44100);
+            var intervalMs = (this.blockFrames / sampleRate) * 1000;
+            intervalMs = Math.max(10, Math.min(intervalMs, 200));
+            if (typeof this.global.setInterval === "function") {
+                this.timerHandle = this.global.setInterval(function() {
+                    self._emit();
+                }, intervalMs);
+                this._clearFn = function(handle) {
+                    if (typeof self.global.clearInterval === "function") {
+                        self.global.clearInterval(handle);
+                    }
+                };
+            } else if (typeof this.global.setTimeout === "function") {
+                (function loop() {
+                    self.timerHandle = self.global.setTimeout(function() {
+                        self._emit();
+                        loop();
+                    }, intervalMs);
+                })();
+                this._clearFn = function(handle) {
+                    if (typeof self.global.clearTimeout === "function") {
+                        self.global.clearTimeout(handle);
+                    }
+                };
+            }
+        }
+
+        connectProcessor(node) {
+            this.processor = node || null;
+            if (!this.processor) return;
+            this._emit();
+            this._schedule();
+        }
+
+        stop() {
+            if (this.timerHandle !== null && this._clearFn) {
+                this._clearFn(this.timerHandle);
+            }
+            this.timerHandle = null;
+            this.processor = null;
+        }
+
+        diagnostics() {
+            return {
+                mode: "file",
+                fileId: this.entry.id,
+                loop: this.loop,
+                blockFrames: this.blockFrames,
+            };
+        }
+    }
+
+    class AudioInputManager {
+        constructor(globalScope) {
+            this.global = globalScope;
+            this.mode = "microphone";
+            this.options = {
+                synthetic: { frequency: 440, amplitude: 0.25, blockFrames: 512 },
+                file: { loop: true, blockFrames: 512 },
+            };
+            this.files = new Map();
+            this.context = null;
+            this.activeSession = null;
+        }
+
+        configure(configuration) {
+            if (!configuration || typeof configuration !== "object") return;
+            if (configuration.mode) {
+                this.mode = String(configuration.mode).toLowerCase();
+            }
+            if (configuration.synthetic && typeof configuration.synthetic === "object") {
+                Object.assign(this.options.synthetic, configuration.synthetic);
+            }
+            if (configuration.file && typeof configuration.file === "object") {
+                Object.assign(this.options.file, configuration.file);
+            }
+            if (configuration.fileId) {
+                this.options.file.id = configuration.fileId;
+            }
+        }
+
+        registerFile(id, payload) {
+            if (!id) throw new Error("audio input file id required");
+            if (!payload || !payload.samples) throw new Error("audio input file samples required");
+            var samples = payload.samples;
+            if (samples instanceof ArrayBuffer) {
+                samples = new Float32Array(samples);
+            } else if (Array.isArray(samples)) {
+                samples = Float32Array.from(samples);
+            } else if (!(samples instanceof Float32Array)) {
+                throw new Error("audio input file samples must be Float32Array or array");
+            }
+            var channels = clampChannels(payload.channels || 1, 1);
+            var sampleRate = payload.sampleRate || 44100;
+            this.files.set(id, {
+                id: id,
+                samples: samples,
+                channels: channels,
+                sampleRate: sampleRate,
+                loop: payload.loop !== undefined ? !!payload.loop : undefined,
+            });
+        }
+
+        unregisterFile(id) {
+            this.files.delete(id);
+        }
+
+        _closeContext() {
+            if (this.context && typeof this.context.close === "function") {
+                try {
+                    this.context.close();
+                } catch (err) {}
+            }
+            this.context = null;
+        }
+
+        _createContext() {
+            var AudioCtx = this.global.AudioContext || this.global.webkitAudioContext;
+            if (!AudioCtx) return null;
+            this._closeContext();
+            try {
+                this.context = new AudioCtx({ latencyHint: "interactive" });
+            } catch (err) {
+                this.context = new AudioCtx();
+            }
+            return this.context;
+        }
+
+        _startMicrophone(context, options) {
+            if (!this.global.navigator || !this.global.navigator.mediaDevices || !this.global.navigator.mediaDevices.getUserMedia) {
+                return Promise.reject(new Error("audio input not supported"));
+            }
+            var constraints = options && options.constraints ? options.constraints : { audio: true };
+            return this.global.navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
+                var source = context.createMediaStreamSource(stream);
+                return new MicrophoneAudioInputSession(this.global, context, source, stream);
+            }.bind(this));
+        }
+
+        _startSynthetic(context, options) {
+            var syntheticOptions = Object.assign({}, this.options.synthetic, options || {});
+            return Promise.resolve(new SyntheticAudioInputSession(this.global, context, syntheticOptions));
+        }
+
+        _startFile(context, options) {
+            var id = (options && options.fileId) || (this.options.file && this.options.file.id);
+            if (!id || !this.files.has(id)) {
+                return Promise.reject(new Error("audio input file not registered"));
+            }
+            var entry = this.files.get(id);
+            var fileOptions = Object.assign({}, this.options.file, options || {});
+            fileOptions.fileId = id;
+            return Promise.resolve(new FileAudioInputSession(this.global, context, entry, fileOptions));
+        }
+
+        startSession(config) {
+            var options = config || {};
+            var mode = options.mode || this.mode || "microphone";
+            mode = String(mode).toLowerCase();
+            this.mode = mode;
+            if (this.activeSession) {
+                this.activeSession.stop();
+                this.activeSession = null;
+            }
+            var context = this._createContext();
+            if (!context) {
+                return Promise.reject(new Error("audio input unavailable"));
+            }
+            if (context.state === "suspended" && typeof context.resume === "function") {
+                context.resume().catch(function() {});
+            }
+            var startPromise;
+            switch (mode) {
+                case "microphone":
+                case "mic":
+                    startPromise = this._startMicrophone(context, options);
+                    break;
+                case "synthetic":
+                case "tone":
+                    startPromise = this._startSynthetic(context, options);
+                    break;
+                case "file":
+                case "buffer":
+                    startPromise = this._startFile(context, options);
+                    break;
+                default:
+                    startPromise = Promise.reject(new Error("unsupported audio input mode: " + mode));
+            }
+            return startPromise.then(function(session) {
+                this.activeSession = session;
+                return { context: context, session: session };
+            }.bind(this)).catch(function(err) {
+                this.stop();
+                throw err;
+            }.bind(this));
+        }
+
+        stop() {
+            if (this.activeSession && typeof this.activeSession.stop === "function") {
+                this.activeSession.stop();
+            }
+            this.activeSession = null;
+            this._closeContext();
+        }
+
+        diagnostics() {
+            return {
+                mode: this.mode,
+                hasContext: !!this.context,
+                sampleRate: this.context ? this.context.sampleRate : null,
+                activeSession: this.activeSession && typeof this.activeSession.diagnostics === "function"
+                    ? this.activeSession.diagnostics()
+                    : null,
+                registeredFiles: Array.from(this.files.keys()),
+            };
+        }
+    }
+
+    Object.extend(SqueakGlobal,
+    "audio", {
+        ensureAudioOutputManager: function ensureAudioOutputManager() {
+            if (!this.audioOutputManager) {
+                this.audioOutputManager = new AudioOutputManager(global);
+            }
+            return this.audioOutputManager;
+        },
+        ensureAudioInputManager: function ensureAudioInputManager() {
+            if (!this.audioInputManager) {
+                this.audioInputManager = new AudioInputManager(global);
+            }
+            return this.audioInputManager;
+        },
+        startAudioOut: function startAudioOut() {
+            var manager = this.ensureAudioOutputManager();
+            var context = manager.ensureContext();
+            if (context && context.state === "suspended" && typeof context.resume === "function") {
+                context.resume().catch(function() {});
+            }
+            return context;
+        },
+        ensureAudioOutputSession: function ensureAudioOutputSession(options) {
+            var manager = this.ensureAudioOutputManager();
+            return manager.ensureSession(options);
+        },
+        stopAudioOut: function stopAudioOut() {
+            if (!this.audioOutputManager) return;
+            this.audioOutputManager.stop();
+            this.audioOutputManager = null;
+        },
+        audioOutputDiagnostics: function audioOutputDiagnostics() {
+            if (!this.audioOutputManager) return { hasContext: false, sessionType: null, supportsWorklet: false };
+            return this.audioOutputManager.diagnostics();
+        },
+        startAudioIn: function startAudioIn(thenDo, errorDo, options) {
+            var manager = this.ensureAudioInputManager();
+            manager.startSession(options || {}).then(function(result) {
+                if (typeof thenDo === "function") {
+                    thenDo(result.context, result.session);
+                }
+            }).catch(function(err) {
+                if (typeof errorDo === "function") {
+                    errorDo(err && err.message ? err.message : String(err));
+                }
+            });
+        },
+        stopAudioIn: function stopAudioIn() {
+            if (this.audioInputManager) {
+                this.audioInputManager.stop();
+            }
+        },
+        configureAudioInput: function configureAudioInput(options) {
+            var manager = this.ensureAudioInputManager();
+            manager.configure(options);
+        },
+        registerAudioInputFile: function registerAudioInputFile(id, payload) {
+            var manager = this.ensureAudioInputManager();
+            manager.registerFile(id, payload || {});
+        },
+        unregisterAudioInputFile: function unregisterAudioInputFile(id) {
+            if (!this.audioInputManager) return;
+            this.audioInputManager.unregisterFile(id);
+        },
+        audioInputDiagnostics: function audioInputDiagnostics() {
+            if (!this.audioInputManager) return { hasContext: false, mode: null, activeSession: null, registeredFiles: [] };
+            return this.audioInputManager.diagnostics();
+        },
+    });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/vm.clipboard.js
+++ b/vm.clipboard.js
@@ -1,0 +1,699 @@
+"use strict";
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_METRICS_STORAGE_KEY = "squeak.clipboard.metrics";
+
+function clonePermissionSnapshot(source) {
+    return {
+        read: Object.assign({ state: "unknown", updatedAt: null }, source && source.read || {}),
+        write: Object.assign({ state: "unknown", updatedAt: null }, source && source.write || {}),
+    };
+}
+
+function safeLocalStorage(global) {
+    try {
+        if (!global || !global.localStorage) return null;
+        var storage = global.localStorage;
+        if (typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
+            return null;
+        }
+        return storage;
+    } catch (_) {
+        return null;
+    }
+}
+
+function getGlobal() {
+    if (typeof globalThis !== "undefined") return globalThis;
+    if (typeof self !== "undefined") return self;
+    if (typeof window !== "undefined") return window;
+    if (typeof global !== "undefined") return global;
+    return {};
+}
+
+function nowTimestamp() {
+    if (typeof Date !== "undefined" && typeof Date.now === "function") {
+        return Date.now();
+    }
+    return 0;
+}
+
+function toErrorLike(error, fallbackName) {
+    if (!error) {
+        return { name: fallbackName || "Error", message: "" };
+    }
+    if (error instanceof Error) {
+        return {
+            name: error.name || fallbackName || "Error",
+            message: error.message || "",
+            code: error.code,
+            type: error.type,
+            reason: error.reason,
+        };
+    }
+    if (typeof error === "string") {
+        return { name: fallbackName || "Error", message: error };
+    }
+    var formatted = { name: fallbackName || (error.name || "Error") };
+    if (error.message) formatted.message = String(error.message);
+    else formatted.message = String(error);
+    if (error.code !== undefined) formatted.code = error.code;
+    if (error.type !== undefined) formatted.type = error.type;
+    if (error.reason !== undefined) formatted.reason = error.reason;
+    return formatted;
+}
+
+function createError(name, message, detail) {
+    var error = new Error(message || name);
+    error.name = name;
+    if (detail && typeof detail === "object") {
+        Object.keys(detail).forEach(function(key) {
+            error[key] = detail[key];
+        });
+    }
+    return error;
+}
+
+function runWithTimeout(factory, timeoutMs, operation) {
+    var useTimeout = typeof timeoutMs === "number" && isFinite(timeoutMs) && timeoutMs > 0;
+    if (!useTimeout) {
+        try {
+            return Promise.resolve().then(factory);
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+    return new Promise(function(resolve, reject) {
+        var settled = false;
+        var timer = setTimeout(function() {
+            if (settled) return;
+            settled = true;
+            var timeoutError = createError(
+                "ClipboardTimeout",
+                "Clipboard " + (operation || "operation") + " timed out after " + timeoutMs + "ms",
+                { operation: operation || "unknown", timeoutMs: timeoutMs }
+            );
+            reject(timeoutError);
+        }, timeoutMs);
+        function cleanup() {
+            if (timer) {
+                clearTimeout(timer);
+                timer = null;
+            }
+        }
+        var promise;
+        try {
+            promise = Promise.resolve().then(factory);
+        } catch (error) {
+            cleanup();
+            reject(error);
+            return;
+        }
+        promise.then(function(value) {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve(value);
+        }, function(error) {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(error);
+        });
+    });
+}
+
+function normalizePermissionState(status) {
+    if (!status) return "unknown";
+    if (typeof status.state === "string" && status.state) return status.state;
+    if (typeof status.status === "string" && status.status) return status.status;
+    return "unknown";
+}
+
+function ensurePermissionListener(status, onChange) {
+    if (!status || typeof status.addEventListener !== "function" || typeof onChange !== "function") return;
+    try {
+        status.addEventListener("change", function() {
+            try {
+                onChange(normalizePermissionState(status));
+            } catch (_) {}
+        });
+    } catch (_) {}
+}
+
+export function createClipboardBridge(options = {}) {
+    var global = getGlobal();
+    var navigatorRef = global && global.navigator ? global.navigator : undefined;
+    var clipboardRef = navigatorRef && navigatorRef.clipboard ? navigatorRef.clipboard : undefined;
+    var permissionsRef = navigatorRef && navigatorRef.permissions ? navigatorRef.permissions : undefined;
+    var logger = typeof options.logger === "function" ? options.logger : null;
+    var notify = typeof options.onStatus === "function" ? options.onStatus : null;
+    var getGesture = typeof options.getUserGesture === "function" ? options.getUserGesture : function() { return false; };
+    var timeoutMs = typeof options.timeoutMs === "number" && options.timeoutMs >= 0 ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+    var storageKey = typeof options.metricsStorageKey === "string" && options.metricsStorageKey
+        ? options.metricsStorageKey
+        : DEFAULT_METRICS_STORAGE_KEY;
+    var storageRef = safeLocalStorage(global);
+    var persistedErrorCounts = {};
+    var persistedUpdatedAt = null;
+    if (storageRef) {
+        try {
+            var rawMetrics = storageRef.getItem(storageKey);
+            if (rawMetrics) {
+                var parsedMetrics = JSON.parse(rawMetrics);
+                if (parsedMetrics && typeof parsedMetrics === "object") {
+                    if (parsedMetrics.errorCounts && typeof parsedMetrics.errorCounts === "object") {
+                        persistedErrorCounts = Object.assign({}, parsedMetrics.errorCounts);
+                    }
+                    if (typeof parsedMetrics.updatedAt === "number" && isFinite(parsedMetrics.updatedAt)) {
+                        persistedUpdatedAt = parsedMetrics.updatedAt;
+                    }
+                }
+            }
+        } catch (_) {}
+    }
+    var initialState = options.initialState && typeof options.initialState === "object" ? options.initialState : null;
+    var initialText = initialState && typeof initialState.cachedText === "string"
+        ? initialState.cachedText
+        : (typeof options.initialText === "string" ? options.initialText : "");
+    var state = {
+        cachedText: normalizeText(initialText),
+        cachedAt: initialState && typeof initialState.cachedAt === "number" ? initialState.cachedAt : (initialText ? nowTimestamp() : null),
+        lastRead: initialState && typeof initialState.lastRead === "number" ? initialState.lastRead : null,
+        lastWrite: initialState && typeof initialState.lastWrite === "number" ? initialState.lastWrite : null,
+        lastError: initialState && typeof initialState.lastError === "object" ? Object.assign({}, initialState.lastError) : null,
+        permission: clonePermissionSnapshot(initialState && initialState.permission),
+        lastStatus: initialState && typeof initialState.lastStatus === "object" ? Object.assign({}, initialState.lastStatus) : null,
+        errorCounts: Object.assign({}, persistedErrorCounts, initialState && typeof initialState.errorCounts === "object" ? initialState.errorCounts : {}),
+        metricsKey: storageKey,
+        metricsUpdatedAt: persistedUpdatedAt,
+        staleDrops: initialState && typeof initialState.staleDrops === "number" ? initialState.staleDrops | 0 : 0,
+    };
+
+    var persistTimer = null;
+
+    function flushMetrics() {
+        if (!storageRef) return;
+        var payload = {
+            errorCounts: Object.assign({}, state.errorCounts),
+            updatedAt: nowTimestamp(),
+        };
+        state.metricsUpdatedAt = payload.updatedAt;
+        try {
+            storageRef.setItem(storageKey, JSON.stringify(payload));
+        } catch (_) {}
+    }
+
+    function schedulePersist() {
+        if (!storageRef || typeof setTimeout !== "function") return;
+        if (persistTimer) return;
+        persistTimer = setTimeout(function() {
+            persistTimer = null;
+            flushMetrics();
+        }, 200);
+    }
+
+    function emit(event, detail) {
+        if (logger) {
+            try {
+                logger(event, detail);
+            } catch (_) {}
+            return;
+        }
+        if (typeof console !== "undefined" && console.debug) {
+            console.debug("[SqueakJS][clipboard]", event, detail || "");
+        }
+    }
+
+    function dispatchStatus(type, detail) {
+        var payload = Object.assign({ type: type, timestamp: nowTimestamp() }, detail || {});
+        state.lastStatus = payload;
+        if (notify) {
+            try {
+                notify(payload);
+            } catch (error) {
+                if (typeof console !== "undefined" && console.warn) {
+                    console.warn("[SqueakJS][clipboard] status callback failed", error);
+                }
+            }
+        } else if (typeof console !== "undefined" && console.warn) {
+            var message = payload && payload.message ? payload.message : type;
+            console.warn("[SqueakJS][clipboard]", message);
+        }
+        return payload;
+    }
+
+    function updatePermission(kind, nextState) {
+        var target = kind === "write" ? state.permission.write : state.permission.read;
+        if (!target || !nextState || typeof nextState !== "object") return;
+        var updatedAt = typeof nextState.updatedAt === "number" && isFinite(nextState.updatedAt)
+            ? nextState.updatedAt
+            : nowTimestamp();
+        Object.keys(nextState).forEach(function(key) {
+            target[key] = nextState[key];
+        });
+        target.updatedAt = updatedAt;
+    }
+
+    function queryPermission(kind) {
+        var name = kind === "write" ? "clipboard-write" : "clipboard-read";
+        if (!permissionsRef || typeof permissionsRef.query !== "function") {
+            updatePermission(kind, { name: name, state: "unknown", supported: false });
+            return Promise.resolve({ name: name, state: "unknown", supported: false });
+        }
+        return permissionsRef.query({ name: name }).then(function(status) {
+            var normalized = normalizePermissionState(status);
+            updatePermission(kind, { name: name, state: normalized, supported: true });
+            ensurePermissionListener(status, function(next) {
+                updatePermission(kind, { name: name, state: next, supported: true });
+            });
+            return { name: name, state: normalized, supported: true };
+        }).catch(function(error) {
+            var formatted = toErrorLike(error, "PermissionError");
+            updatePermission(kind, { name: name, state: "error", supported: true, error: formatted });
+            return { name: name, state: "error", supported: true, error: formatted };
+        });
+    }
+
+    function recordError(operation, error) {
+        var formatted = toErrorLike(error, "ClipboardError");
+        var timestamp = nowTimestamp();
+        state.lastError = {
+            operation: operation,
+            error: formatted,
+            timestamp: timestamp,
+        };
+        var errorKey = formatted && formatted.name ? formatted.name
+            : (formatted && formatted.type ? formatted.type : "Error");
+        state.errorCounts[errorKey] = (state.errorCounts[errorKey] || 0) + 1;
+        state.metricsUpdatedAt = timestamp;
+        schedulePersist();
+        return formatted;
+    }
+
+    function normalizeText(text) {
+        if (typeof text === "string") return text;
+        if (text === null || text === undefined) return "";
+        return String(text);
+    }
+
+    function readText(options) {
+        options = options || {};
+        var fallbackToCache = options.fallbackToCache !== false;
+        var requireGesture = options.requireGesture !== false;
+        var permissionInfo;
+        return queryPermission("read").then(function(info) {
+            permissionInfo = info || { state: "unknown" };
+            if (permissionInfo.state === "denied") {
+                var deniedError = createError("ClipboardPermissionDenied", "Clipboard read permission denied", {
+                    permission: permissionInfo.name,
+                    operation: "read",
+                });
+                dispatchStatus("permission-denied", {
+                    operation: "read",
+                    permission: permissionInfo.state,
+                    message: "Clipboard read permission was denied.",
+                });
+                recordError("read", deniedError);
+                if (fallbackToCache) {
+                    return attachSnapshot({
+                        text: state.cachedText,
+                        fromCache: true,
+                        permission: permissionInfo.state,
+                        error: toErrorLike(deniedError, "ClipboardPermissionDenied"),
+                    });
+                }
+                throw deniedError;
+            }
+            if (requireGesture && permissionInfo.state === "prompt" && !getGesture()) {
+                var gestureError = createError("ClipboardGestureRequired", "Clipboard read requires a user gesture", {
+                    permission: permissionInfo.name,
+                    operation: "read",
+                });
+                dispatchStatus("gesture-required", {
+                    operation: "read",
+                    permission: permissionInfo.state,
+                    message: "Clipboard read requires a focused user gesture.",
+                });
+                recordError("read", gestureError);
+                if (fallbackToCache) {
+                    return attachSnapshot({
+                        text: state.cachedText,
+                        fromCache: true,
+                        permission: permissionInfo.state,
+                        error: toErrorLike(gestureError, "ClipboardGestureRequired"),
+                    });
+                }
+                throw gestureError;
+            }
+            if (!clipboardRef || typeof clipboardRef.readText !== "function") {
+                var unavailableError = createError("ClipboardUnavailable", "navigator.clipboard.readText is not available", {
+                    operation: "read",
+                });
+                dispatchStatus("unavailable", {
+                    operation: "read",
+                    permission: permissionInfo.state,
+                    message: "Async clipboard read is not supported by this browser.",
+                });
+                recordError("read", unavailableError);
+                if (fallbackToCache) {
+                    return attachSnapshot({
+                        text: state.cachedText,
+                        fromCache: true,
+                        permission: permissionInfo.state,
+                        error: toErrorLike(unavailableError, "ClipboardUnavailable"),
+                    });
+                }
+                throw unavailableError;
+            }
+            emit("clipboard.request", { operation: "read", permission: permissionInfo.state });
+            return runWithTimeout(function() {
+                return clipboardRef.readText();
+            }, timeoutMs, "read").then(function(text) {
+                var normalized = normalizeText(text);
+                var timestamp = nowTimestamp();
+                setCachedText(normalized, timestamp);
+                state.lastRead = timestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: false,
+                    permission: permissionInfo.state,
+                });
+            }).catch(function(error) {
+                var formattedError = toErrorLike(error, "ClipboardError");
+                dispatchStatus("error", {
+                    operation: "read",
+                    permission: permissionInfo.state,
+                    message: formattedError.message || "Clipboard read failed",
+                    error: formattedError,
+                });
+                recordError("read", error);
+                if (fallbackToCache) {
+                    return attachSnapshot({
+                        text: state.cachedText,
+                        fromCache: true,
+                        permission: permissionInfo.state,
+                        error: formattedError,
+                    });
+                }
+                throw error;
+            });
+        });
+    }
+
+    function writeText(text, options) {
+        options = options || {};
+        var requireGesture = options.requireGesture !== false;
+        var normalized = normalizeText(text);
+        var permissionInfo;
+        return queryPermission("write").then(function(info) {
+            permissionInfo = info || { state: "unknown" };
+            if (permissionInfo.state === "denied") {
+                var deniedError = createError("ClipboardPermissionDenied", "Clipboard write permission denied", {
+                    permission: permissionInfo.name,
+                    operation: "write",
+                });
+                dispatchStatus("permission-denied", {
+                    operation: "write",
+                    permission: permissionInfo.state,
+                    message: "Clipboard write permission was denied.",
+                });
+                recordError("write", deniedError);
+                var deniedTimestamp = nowTimestamp();
+                setCachedText(normalized, deniedTimestamp);
+                state.lastWrite = deniedTimestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: true,
+                    permission: permissionInfo.state,
+                    error: toErrorLike(deniedError, "ClipboardPermissionDenied"),
+                });
+            }
+            if (requireGesture && permissionInfo.state === "prompt" && !getGesture()) {
+                var gestureError = createError("ClipboardGestureRequired", "Clipboard write requires a user gesture", {
+                    permission: permissionInfo.name,
+                    operation: "write",
+                });
+                dispatchStatus("gesture-required", {
+                    operation: "write",
+                    permission: permissionInfo.state,
+                    message: "Clipboard write requires a focused user gesture.",
+                });
+                recordError("write", gestureError);
+                var gestureTimestamp = nowTimestamp();
+                setCachedText(normalized, gestureTimestamp);
+                state.lastWrite = gestureTimestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: true,
+                    permission: permissionInfo.state,
+                    error: toErrorLike(gestureError, "ClipboardGestureRequired"),
+                });
+            }
+            if (!clipboardRef || typeof clipboardRef.writeText !== "function") {
+                var unavailableError = createError("ClipboardUnavailable", "navigator.clipboard.writeText is not available", {
+                    operation: "write",
+                });
+                dispatchStatus("unavailable", {
+                    operation: "write",
+                    permission: permissionInfo.state,
+                    message: "Async clipboard write is not supported by this browser.",
+                });
+                recordError("write", unavailableError);
+                var unavailableTimestamp = nowTimestamp();
+                setCachedText(normalized, unavailableTimestamp);
+                state.lastWrite = unavailableTimestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: true,
+                    permission: permissionInfo.state,
+                    error: toErrorLike(unavailableError, "ClipboardUnavailable"),
+                });
+            }
+            emit("clipboard.request", { operation: "write", permission: permissionInfo.state });
+            return runWithTimeout(function() {
+                return clipboardRef.writeText(normalized);
+            }, timeoutMs, "write").then(function() {
+                var timestamp = nowTimestamp();
+                setCachedText(normalized, timestamp);
+                state.lastWrite = timestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: false,
+                    permission: permissionInfo.state,
+                });
+            }).catch(function(error) {
+                var formattedError = toErrorLike(error, "ClipboardError");
+                dispatchStatus("error", {
+                    operation: "write",
+                    permission: permissionInfo.state,
+                    message: formattedError.message || "Clipboard write failed",
+                    error: formattedError,
+                });
+                recordError("write", error);
+                var failureTimestamp = nowTimestamp();
+                setCachedText(normalized, failureTimestamp);
+                state.lastWrite = failureTimestamp;
+                return attachSnapshot({
+                    text: normalized,
+                    fromCache: true,
+                    permission: permissionInfo.state,
+                    error: formattedError,
+                });
+            });
+        });
+    }
+
+    function getCachedText() {
+        return state.cachedText;
+    }
+
+    function setCachedText(text, timestamp) {
+        var normalized = normalizeText(text);
+        var ts = typeof timestamp === "number" && isFinite(timestamp) ? timestamp : nowTimestamp();
+        if (state.cachedAt !== null && ts < state.cachedAt) {
+            state.staleDrops++;
+            return state.cachedText;
+        }
+        state.cachedText = normalized;
+        state.cachedAt = ts;
+        return state.cachedText;
+    }
+
+    function mergeSnapshot(snapshot) {
+        if (!snapshot || typeof snapshot !== "object") return getState();
+        if (snapshot.permission && typeof snapshot.permission === "object") {
+            if (snapshot.permission.read) updatePermission("read", snapshot.permission.read);
+            if (snapshot.permission.write) updatePermission("write", snapshot.permission.write);
+        }
+        if (snapshot.cachedText !== undefined || snapshot.text !== undefined) {
+            var nextText = snapshot.cachedText !== undefined ? snapshot.cachedText : snapshot.text;
+            if (nextText !== undefined) {
+                var ts = typeof snapshot.cachedAt === "number" && isFinite(snapshot.cachedAt)
+                    ? snapshot.cachedAt
+                    : (typeof snapshot.timestamp === "number" && isFinite(snapshot.timestamp)
+                        ? snapshot.timestamp
+                        : nowTimestamp());
+                setCachedText(nextText, ts);
+            }
+        }
+        if (typeof snapshot.lastRead === "number" && isFinite(snapshot.lastRead) && (!state.lastRead || snapshot.lastRead > state.lastRead)) {
+            state.lastRead = snapshot.lastRead;
+        }
+        if (typeof snapshot.lastWrite === "number" && isFinite(snapshot.lastWrite) && (!state.lastWrite || snapshot.lastWrite > state.lastWrite)) {
+            state.lastWrite = snapshot.lastWrite;
+        }
+        if (snapshot.lastError && typeof snapshot.lastError === "object") {
+            if (!state.lastError || !state.lastError.timestamp || (snapshot.lastError.timestamp && snapshot.lastError.timestamp >= state.lastError.timestamp)) {
+                state.lastError = Object.assign({}, snapshot.lastError);
+            }
+        }
+        if (snapshot.lastStatus && typeof snapshot.lastStatus === "object") {
+            state.lastStatus = Object.assign({}, snapshot.lastStatus);
+        }
+        if (snapshot.errorCounts && typeof snapshot.errorCounts === "object") {
+            var metricsChanged = false;
+            Object.keys(snapshot.errorCounts).forEach(function(key) {
+                var value = Number(snapshot.errorCounts[key]);
+                if (!isFinite(value)) return;
+                if (value > (state.errorCounts[key] || 0)) {
+                    state.errorCounts[key] = value;
+                    metricsChanged = true;
+                }
+            });
+            if (metricsChanged) {
+                state.metricsUpdatedAt = nowTimestamp();
+                schedulePersist();
+            }
+        }
+        if (typeof snapshot.staleDrops === "number" && snapshot.staleDrops > state.staleDrops) {
+            state.staleDrops = snapshot.staleDrops | 0;
+        }
+        return getState();
+    }
+
+    function getState() {
+        return {
+            cachedText: state.cachedText,
+            cachedAt: state.cachedAt,
+            lastRead: state.lastRead,
+            lastWrite: state.lastWrite,
+            lastError: state.lastError ? Object.assign({}, state.lastError) : null,
+            permission: {
+                read: Object.assign({}, state.permission.read),
+                write: Object.assign({}, state.permission.write),
+            },
+            lastStatus: state.lastStatus ? Object.assign({}, state.lastStatus) : null,
+            errorCounts: Object.assign({}, state.errorCounts),
+            metricsKey: state.metricsKey,
+            metricsUpdatedAt: state.metricsUpdatedAt,
+            staleDrops: state.staleDrops,
+        };
+    }
+
+    function attachSnapshot(base) {
+        var snapshot = getState();
+        base.cachedAt = snapshot.cachedAt;
+        base.lastRead = snapshot.lastRead;
+        base.lastWrite = snapshot.lastWrite;
+        base.lastStatus = snapshot.lastStatus;
+        base.lastErrorDetail = snapshot.lastError;
+        base.permissionDetail = snapshot.permission;
+        base.staleDrops = snapshot.staleDrops;
+        base.errorCounts = snapshot.errorCounts;
+        base.metricsKey = snapshot.metricsKey;
+        base.metricsUpdatedAt = snapshot.metricsUpdatedAt;
+        base.state = snapshot;
+        return base;
+    }
+
+    return {
+        readText: readText,
+        writeText: writeText,
+        getCachedText: getCachedText,
+        setCachedText: setCachedText,
+        mergeSnapshot: mergeSnapshot,
+        getState: getState,
+        attachSnapshot: attachSnapshot,
+    };
+}
+
+export function createClipboardRequestQueue(executor = {}) {
+    if (!executor || typeof executor.read !== "function" || typeof executor.write !== "function") {
+        throw new TypeError("createClipboardRequestQueue requires read and write handlers");
+    }
+
+    var tail = Promise.resolve();
+    var state = {
+        pending: 0,
+        last: null,
+    };
+
+    function enqueue(kind, factory) {
+        state.pending++;
+        var startedAt = null;
+        var run = tail.then(function() {
+            startedAt = nowTimestamp();
+            return Promise.resolve().then(factory);
+        });
+        run = run.then(function(result) {
+            state.pending--;
+            state.last = {
+                kind: kind,
+                status: "fulfilled",
+                result: result,
+                startedAt: startedAt,
+                finishedAt: nowTimestamp(),
+            };
+            return result;
+        }, function(error) {
+            state.pending--;
+            state.last = {
+                kind: kind,
+                status: "rejected",
+                error: toErrorLike(error, "ClipboardError"),
+                startedAt: startedAt,
+                finishedAt: nowTimestamp(),
+            };
+            throw error;
+        });
+        tail = run.catch(function() {});
+        return run;
+    }
+
+    function cloneOptions(options) {
+        if (!options || typeof options !== "object") return {};
+        var copy = {};
+        Object.keys(options).forEach(function(key) {
+            copy[key] = options[key];
+        });
+        return copy;
+    }
+
+    return {
+        enqueueRead: function(options) {
+            var opts = cloneOptions(options);
+            return enqueue("read", function() {
+                return executor.read.call(executor, opts);
+            });
+        },
+        enqueueWrite: function(text, options) {
+            var opts = cloneOptions(options);
+            return enqueue("write", function() {
+                return executor.write.call(executor, text, opts);
+            });
+        },
+        getState: function() {
+            return {
+                pending: state.pending,
+                last: state.last ? Object.assign({}, state.last) : null,
+            };
+        },
+        clear: function() {
+            tail = Promise.resolve();
+            state.pending = 0;
+            state.last = null;
+        },
+    };
+}
+

--- a/vm.files.browser.js
+++ b/vm.files.browser.js
@@ -327,11 +327,25 @@ Object.extend(Squeak,
         entry[4] = contents.byteLength || contents.length || 0;
         Squeak.Settings["squeak:" + path.dirname] = JSON.stringify(directory);
         // put file contents (async)
+        var storageVFS = Squeak.StorageVFS;
         this.dbTransaction("readwrite", "put " + filepath,
             function(fileStore) {
                 fileStore.put(contents, path.fullname);
             },
             function transactionComplete() {
+                if (storageVFS && typeof storageVFS.notifyWrite === "function") {
+                    try {
+                        storageVFS.notifyWrite(path.fullname, contents, {
+                            size: entry[4],
+                            updatedAt: now,
+                            directory: path.dirname,
+                        });
+                    } catch (error) {
+                        if (console && console.warn) {
+                            console.warn("[SqueakJS][storage] VFS notifyWrite failed", error);
+                        }
+                    }
+                }
                 if (optSuccess) optSuccess();
             });
         return entry;
@@ -346,8 +360,22 @@ Object.extend(Squeak,
         if (Squeak.debugFiles) console.log("Deleting " + path.fullname);
         if (entryOnly) return true;
         // delete file contents (async)
+        var storageVFS = Squeak.StorageVFS;
         this.dbTransaction("readwrite", "delete " + filepath, function(fileStore) {
             fileStore.delete(path.fullname);
+        }, function transactionComplete() {
+            if (storageVFS && typeof storageVFS.notifyDelete === "function") {
+                try {
+                    storageVFS.notifyDelete(path.fullname, {
+                        updatedAt: Squeak.totalSeconds(),
+                        directory: path.dirname,
+                    });
+                } catch (error) {
+                    if (console && console.warn) {
+                        console.warn("[SqueakJS][storage] VFS notifyDelete failed", error);
+                    }
+                }
+            }
         });
         return true;
     },
@@ -368,9 +396,25 @@ Object.extend(Squeak,
         // move file contents (async)
         this.fileGet(oldpath.fullname,
             function success(contents) {
+                var storageVFS = Squeak.StorageVFS;
                 this.dbTransaction("readwrite", "rename " + oldpath.fullname + " to " + newpath.fullname, function(fileStore) {
                     fileStore.delete(oldpath.fullname);
                     fileStore.put(contents, newpath.fullname);
+                }, function transactionComplete() {
+                    if (storageVFS && typeof storageVFS.notifyRename === "function") {
+                        try {
+                            storageVFS.notifyRename(oldpath.fullname, newpath.fullname, {
+                                contents: contents,
+                                size: entry[4],
+                                updatedAt: Squeak.totalSeconds(),
+                                directory: newpath.dirname,
+                            });
+                        } catch (error) {
+                            if (console && console.warn) {
+                                console.warn("[SqueakJS][storage] VFS notifyRename failed", error);
+                            }
+                        }
+                    }
                 });
             }.bind(this),
             function error(msg) {

--- a/vm.input.browser.js
+++ b/vm.input.browser.js
@@ -1,3 +1,5 @@
+import { getStorageQuotaState, drainEventsAsJSON, setStorageQuotaWarningSemaphore } from "./vm.storage.quota.js";
+
 "use strict";
 /*
  * Copyright (c) 2013-2025 Vanessa Freudenberg
@@ -40,9 +42,28 @@ Object.extend(Squeak.Primitives.prototype,
             if (this.display.readFromSystemClipboard) clipBoardPromise = this.display.readFromSystemClipboard();
             if (clipBoardPromise) {
                 var unfreeze = this.vm.freeze();
-                clipBoardPromise
-                    .then(() => this.vm.popNandPush(1, this.makeStString(this.display.clipboardString)))
-                    .catch(() => this.vm.popNandPush(1, this.vm.nilObj))
+                Promise.resolve(clipBoardPromise)
+                    .then((result) => {
+                        var text = result;
+                        if (result && typeof result === "object" && typeof result.text === "string") {
+                            text = result.text;
+                        }
+                        if (typeof text === "string") {
+                            this.display.clipboardString = text;
+                            this.display.clipboardStringChanged = false;
+                            this.vm.popNandPush(1, this.makeStString(text));
+                            return;
+                        }
+                        if (typeof this.display.clipboardString === "string") {
+                            this.vm.popNandPush(1, this.makeStString(this.display.clipboardString));
+                        } else {
+                            this.vm.popNandPush(1, this.vm.nilObj);
+                        }
+                    })
+                    .catch((error) => {
+                        this.display.clipboardLastError = error;
+                        this.vm.popNandPush(1, this.vm.nilObj);
+                    })
                     .finally(unfreeze);
             } else {
                 if (typeof(this.display.clipboardString) !== 'string') return false;
@@ -54,13 +75,62 @@ Object.extend(Squeak.Primitives.prototype,
                 this.display.clipboardString = stringObj.bytesAsString();
                 this.display.clipboardStringChanged = true; // means it should be written to system clipboard
                 if (this.display.writeToSystemClipboard) {
-                    // no need to wait for the promise
-                    this.display.writeToSystemClipboard();
+                    var writePromise = this.display.writeToSystemClipboard();
+                    if (writePromise && typeof writePromise.then === "function") {
+                        var unfreezeWrite = this.vm.freeze();
+                        Promise.resolve(writePromise)
+                            .catch((error) => {
+                                this.display.clipboardLastError = error;
+                            })
+                            .finally(unfreezeWrite);
+                    }
                 }
             }
             this.vm.pop();
         }
         return true;
+    },
+    primitiveClipboardDiagnostics: function(argCount) {
+        if (argCount !== 0) return false;
+        var diagnostics = null;
+        if (this.display && typeof this.display.getClipboardDiagnostics === "function") {
+            try {
+                diagnostics = this.display.getClipboardDiagnostics();
+            } catch (_) {
+                diagnostics = null;
+            }
+        }
+        var json = "{}";
+        if (diagnostics) {
+            try {
+                json = JSON.stringify(diagnostics);
+            } catch (_) {
+                json = "{}";
+            }
+        }
+        return this.popNandPushIfOK(argCount + 1, this.makeStString(json));
+    },
+    primitiveStorageQuotaState: function(argCount) {
+        if (argCount !== 0) return false;
+        var json = "{}";
+        try {
+            json = JSON.stringify(getStorageQuotaState());
+        } catch (_) {
+            json = "{}";
+        }
+        return this.popNandPushIfOK(argCount + 1, this.makeStString(json));
+    },
+    primitiveStorageQuotaDrainEvents: function(argCount) {
+        if (argCount !== 0) return false;
+        var json = drainEventsAsJSON();
+        return this.popNandPushIfOK(argCount + 1, this.makeStString(json));
+    },
+    primitiveStorageQuotaSetSemaphore: function(argCount) {
+        if (argCount !== 1) return false;
+        var index = this.stackInteger(0);
+        if (!this.success) return false;
+        setStorageQuotaWarningSemaphore(index);
+        return this.popNIfOK(argCount);
     },
     primitiveKeyboardNext: function(argCount) {
         return this.popNandPushIfOK(argCount+1, this.ensureSmallInt(this.display.keys.shift()));

--- a/vm.plugins.sound.browser.js
+++ b/vm.plugins.sound.browser.js
@@ -32,111 +32,70 @@ Object.extend(Squeak.Primitives.prototype,
             stereoFlag = this.stackBoolean(argCount-3),
             semaIndex = argCount > 3 ? this.stackInteger(argCount-4) : 0;
         if (!this.success) return false;
-        this.audioContext = Squeak.startAudioOut();
-        if (!this.audioContext) {
+        var channelCount = stereoFlag ? 2 : 1;
+        var session = Squeak.ensureAudioOutputSession({
+            bufferFrames: bufFrames,
+            sampleRate: samplesPerSec,
+            channels: channelCount,
+            onBufferFreed: function() {
+                if (this.audioSema) this.signalSemaphoreWithIndex(this.audioSema);
+                this.vm.forceInterruptCheck();
+            }.bind(this),
+        });
+        if (!session) {
             this.vm.warnOnce("could not initialize audio");
             return false;
         }
+        this.audioSession = session;
+        this.audioContext = session.context || Squeak.startAudioOut();
         this.audioSema = semaIndex; // signal when ready to accept another buffer of samples
-        this.audioNextTimeSlot = 0;
-        this.audioBuffersReady = [];
-        this.audioBuffersUnused = [
-            this.audioContext.createBuffer(stereoFlag ? 2 : 1, bufFrames, samplesPerSec),
-            this.audioContext.createBuffer(stereoFlag ? 2 : 1, bufFrames, samplesPerSec),
-        ];
-        // console.log("sound: started");
+        this.audioBufferFrames = bufFrames;
+        this.audioChannelCount = channelCount;
         return this.popNIfOK(argCount);
     },
-    snd_playNextBuffer: function() {
-        if (!this.audioContext || this.audioBuffersReady.length === 0)
-            return;
-        var source = this.audioContext.createBufferSource();
-        source.buffer = this.audioBuffersReady.shift();
-        source.connect(this.audioContext.destination);
-        if (this.audioNextTimeSlot < this.audioContext.currentTime) {
-            // if (this.audioNextTimeSlot > 0)
-            //     console.log("sound " + this.audioContext.currentTime.toFixed(3) +
-            //         ": buffer underrun by " + (this.audioContext.currentTime - this.audioNextTimeSlot).toFixed(3) + " s");
-            this.audioNextTimeSlot = this.audioContext.currentTime;
-        }
-        source.start(this.audioNextTimeSlot);
-        //console.log("sound " + this.audioContext.currentTime.toFixed(3) +
-        //    ": scheduling from " + this.audioNextTimeSlot.toFixed(3) +
-        //    " to " + (this.audioNextTimeSlot + source.buffer.duration).toFixed(3));
-        this.audioNextTimeSlot += source.buffer.duration;
-        // source.onended is unreliable, using a timeout instead
-        window.setTimeout(function() {
-            // if the vm was shut down, forceInterruptCheck will be null
-            if (!this.audioContext || !this.vm.forceInterruptCheck) return;
-            // console.log("sound " + this.audioContext.currentTime.toFixed(3) +
-            //    ": done, next time slot " + this.audioNextTimeSlot.toFixed(3));
-            this.audioBuffersUnused.push(source.buffer);
-            if (this.audioSema) this.signalSemaphoreWithIndex(this.audioSema);
-            this.vm.forceInterruptCheck();
-        }.bind(this), (this.audioNextTimeSlot - this.audioContext.currentTime) * 1000);
-        this.snd_playNextBuffer();
-    },
     snd_primitiveSoundAvailableSpace: function(argCount) {
-        if (!this.audioContext) {
+        if (!this.audioSession) {
             console.warn("sound: no audio context");
             return false;
         }
-        var available = 0;
-        if (this.audioBuffersUnused.length > 0) {
-            var buf = this.audioBuffersUnused[0];
-            available = buf.length * buf.numberOfChannels * 2;
-        }
+        var available = this.audioSession.availableByteCount();
         return this.popNandPushIfOK(argCount + 1, available);
     },
     snd_primitiveSoundPlaySamples: function(argCount) {
-        if (!this.audioContext || this.audioBuffersUnused.length === 0) {
-            console.warn("sound: play but no free buffers");
+        if (!this.audioSession) {
+            console.warn("sound: play but no audio session");
             return false;
         }
         var count = this.stackInteger(2),
             sqSamples = this.stackNonInteger(1).wordsAsInt16Array(),
             startIndex = this.stackInteger(0) - 1;
         if (!this.success || !sqSamples) return false;
-        var buffer = this.audioBuffersUnused.shift(),
-            channels = buffer.numberOfChannels;
-        for (var channel = 0; channel < channels; channel++) {
-            var jsSamples = buffer.getChannelData(channel),
-                index = startIndex + channel;
-            for (var i = 0; i < count; i++) {
-                jsSamples[i] = sqSamples[index] / 32768;    // int16 -> float32
-                index += channels;
-            }
+        if (!this.audioSession.enqueueSamples(sqSamples, startIndex, count)) {
+            console.warn("sound: insufficient buffer space for samples");
+            return false;
         }
-        this.audioBuffersReady.push(buffer);
-        this.snd_playNextBuffer();
         return this.popNIfOK(argCount);
     },
     snd_primitiveSoundPlaySilence: function(argCount) {
-        if (!this.audioContext || this.audioBuffersUnused.length === 0) {
-            console.warn("sound: play but no free buffers");
+        if (!this.audioSession) {
+            console.warn("sound: play but no audio session");
             return false;
         }
-        var buffer = this.audioBuffersUnused.shift(),
-            channels = buffer.numberOfChannels,
-            count = buffer.length;
-        for (var channel = 0; channel < channels; channel++) {
-            var jsSamples = buffer.getChannelData(channel);
-            for (var i = 0; i < count; i++)
-                jsSamples[i] = 0;
+        if (!this.audioSession.enqueueSilence(this.audioBufferFrames)) {
+            console.warn("sound: insufficient buffer space for silence");
+            return false;
         }
-        this.audioBuffersReady.push(buffer);
-        this.snd_playNextBuffer();
-        return this.popNandPushIfOK(argCount + 1, count);
+        return this.popNandPushIfOK(argCount + 1, this.audioBufferFrames);
     },
     snd_primitiveSoundStop: function(argCount) {
-        if (this.audioContext) {
-            this.audioContext = null;
-            this.audioBuffersReady = null;
-            this.audioBuffersUnused = null;
-            this.audioNextTimeSlot = 0;
-            this.audioSema = 0;
-            // console.log("sound: stopped");
+        if (this.audioSession) {
+            this.audioSession.stop();
+            this.audioSession = null;
         }
+        this.audioContext = null;
+        this.audioSema = 0;
+        this.audioBufferFrames = 0;
+        this.audioChannelCount = 0;
         return this.popNIfOK(argCount);
     },
     snd_primitiveSoundStartRecording: function(argCount) {
@@ -150,18 +109,15 @@ Object.extend(Squeak.Primitives.prototype,
             unfreeze = this.vm.freeze(),
             self = this;
         Squeak.startAudioIn(
-            function onSuccess(audioContext, source) {
-                // console.log("sound: recording started")
+            function onSuccess(audioContext, session) {
                 self.audioInContext = audioContext;
-                self.audioInSource = source;
+                self.audioInSession = session;
                 self.audioInSema = semaIndex;
                 self.audioInBuffers = [];
                 self.audioInBufferIndex = 0;
                 self.audioInOverSample = 1;
-                // if sample rate is still too high, adjust oversampling
                 while (samplesPerSec * self.audioInOverSample < self.audioInContext.sampleRate)
                     self.audioInOverSample *= 2;
-                // make a buffer of at least 100 ms
                 var bufferSize = self.audioInOverSample * 1024;
                 while (bufferSize / self.audioInContext.sampleRate < 0.1)
                     bufferSize *= 2;
@@ -169,8 +125,14 @@ Object.extend(Squeak.Primitives.prototype,
                 self.audioInProcessor.onaudioprocess = function(event) {
                     self.snd_recordNextBuffer(event.inputBuffer);
                 };
-                self.audioInSource.connect(self.audioInProcessor);
-                self.audioInProcessor.connect(audioContext.destination);
+                if (session && typeof session.connectProcessor === "function") {
+                    session.connectProcessor(self.audioInProcessor);
+                } else if (session && typeof session.connect === "function") {
+                    session.connect(self.audioInProcessor);
+                }
+                if (self.audioInProcessor && typeof self.audioInProcessor.connect === "function") {
+                    self.audioInProcessor.connect(audioContext.destination);
+                }
                 self.vm.popN(argCount);
                 window.setTimeout(unfreeze, 0);
             },
@@ -178,6 +140,10 @@ Object.extend(Squeak.Primitives.prototype,
                 console.warn(msg);
                 self.vm.sendAsPrimitiveFailure(rcvr, method, argCount);
                 window.setTimeout(unfreeze, 0);
+            },
+            {
+                sampleRate: samplesPerSec,
+                channels: stereoFlag ? 2 : 1,
             });
         return true;
     },
@@ -234,12 +200,16 @@ Object.extend(Squeak.Primitives.prototype,
     },
     snd_primitiveSoundStopRecording: function(argCount) {
         if (this.audioInContext) {
-            this.audioInSource.disconnect();
-            this.audioInProcessor.disconnect();
+            if (this.audioInSession && typeof this.audioInSession.stop === "function") {
+                this.audioInSession.stop();
+            }
+            if (this.audioInProcessor && typeof this.audioInProcessor.disconnect === "function") {
+                this.audioInProcessor.disconnect();
+            }
             this.audioInContext = null;
             this.audioInSema = 0;
             this.audioInBuffers = null;
-            this.audioInSource = null;
+            this.audioInSession = null;
             this.audioInProcessor = null;
             console.log("sound recording stopped")
         }
@@ -248,6 +218,24 @@ Object.extend(Squeak.Primitives.prototype,
     },
     snd_primitiveSoundSetRecordLevel: function(argCount) {
         this.vm.warnOnce("sound set record level not supported");
+        return this.popNIfOK(argCount);
+    },
+    snd_primitiveSoundConfigureRecordingSource: function(argCount) {
+        if (argCount < 1 || argCount > 2) return false;
+        var modeObj = this.stackNonInteger(argCount - 1);
+        if (!modeObj || !modeObj.bytesAsString) return false;
+        var mode = modeObj.bytesAsString();
+        var identifier = null;
+        if (argCount === 2) {
+            var idObj = this.stackValue(0);
+            if (idObj !== this.vm.nilObj) {
+                if (!idObj || typeof idObj.bytesAsString !== "function") return false;
+                identifier = idObj.bytesAsString();
+            }
+        }
+        var config = { mode: mode };
+        if (identifier !== null) config.fileId = identifier;
+        Squeak.configureAudioInput(config);
         return this.popNIfOK(argCount);
     },
 });

--- a/vm.storage.quota.js
+++ b/vm.storage.quota.js
@@ -1,0 +1,473 @@
+"use strict";
+
+const DEFAULT_THRESHOLDS = {
+    notice: 0.5,
+    warning: 0.75,
+    critical: 0.9,
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 30000;
+const HISTORY_LIMIT = 20;
+
+const state = {
+    monitorStarted: false,
+    pollInterval: DEFAULT_POLL_INTERVAL_MS,
+    thresholds: Object.assign({}, DEFAULT_THRESHOLDS),
+    history: [],
+    events: [],
+    listeners: [],
+    warningSemaphore: null,
+    evictionHandler: null,
+    evictionInFlight: false,
+    lastLevels: {},
+    manifestSummary: {
+        totalBytes: 0,
+        fileCount: 0,
+        files: {},
+        updatedAt: null,
+    },
+    supported: false,
+    storageEstimateSupported: false,
+    lastEstimate: null,
+    pendingTimer: null,
+    sampleInFlight: null,
+    lastError: null,
+    lastEviction: null,
+};
+
+function getGlobalObject() {
+    if (typeof globalThis !== "undefined") return globalThis;
+    if (typeof self !== "undefined") return self;
+    if (typeof window !== "undefined") return window;
+    if (typeof global !== "undefined") return global;
+    return {};
+}
+
+function ensureQuotaNamespace() {
+    const global = getGlobalObject();
+    if (!global.Squeak) global.Squeak = {};
+    if (!global.Squeak.StorageQuota || typeof global.Squeak.StorageQuota !== "object") {
+        global.Squeak.StorageQuota = {};
+    }
+    return global.Squeak.StorageQuota;
+}
+
+function cloneThresholds(thresholds) {
+    const result = Object.assign({}, DEFAULT_THRESHOLDS);
+    if (thresholds && typeof thresholds === "object") {
+        ["notice", "warning", "critical"].forEach(function(level) {
+            const value = thresholds[level];
+            if (typeof value === "number" && isFinite(value) && value > 0) {
+                result[level] = Math.max(0, Math.min(1, value));
+            }
+        });
+    }
+    return result;
+}
+
+function setThresholds(thresholds) {
+    state.thresholds = cloneThresholds(thresholds);
+    return state.thresholds;
+}
+
+function setPollInterval(pollIntervalMs) {
+    if (typeof pollIntervalMs === "number" && isFinite(pollIntervalMs) && pollIntervalMs >= 0) {
+        state.pollInterval = pollIntervalMs;
+    }
+    return state.pollInterval;
+}
+
+function clearPendingTimer() {
+    if (state.pendingTimer) {
+        clearTimeout(state.pendingTimer);
+        state.pendingTimer = null;
+    }
+}
+
+function scheduleNextSample(delayMs) {
+    clearPendingTimer();
+    const delay = typeof delayMs === "number" && delayMs >= 0 ? delayMs : state.pollInterval;
+    if (!delay || delay <= 0) {
+        return;
+    }
+    state.pendingTimer = setTimeout(function() {
+        state.pendingTimer = null;
+        forceSample();
+    }, delay);
+}
+
+function normalizeEstimate(estimate, manifestSummary) {
+    const usage = typeof estimate.usage === "number" && estimate.usage >= 0
+        ? estimate.usage
+        : manifestSummary.totalBytes;
+    const quota = typeof estimate.quota === "number" && estimate.quota > 0
+        ? estimate.quota
+        : (state.lastEstimate && typeof state.lastEstimate.quota === "number" && state.lastEstimate.quota > 0
+            ? state.lastEstimate.quota
+            : Math.max(usage, manifestSummary.totalBytes || 0));
+    return {
+        usage,
+        quota,
+        persisted: !!estimate.persisted,
+    };
+}
+
+function summarizeManifest(manifest) {
+    if (!manifest || typeof manifest !== "object") {
+        return {
+            totalBytes: 0,
+            fileCount: 0,
+            files: {},
+            updatedAt: null,
+        };
+    }
+    const files = manifest.files && typeof manifest.files === "object"
+        ? manifest.files
+        : {};
+    const fileCount = Object.keys(files).length;
+    const totalBytes = typeof manifest.totalBytes === "number" && manifest.totalBytes >= 0
+        ? manifest.totalBytes
+        : Object.keys(files).reduce(function(sum, key) {
+            const entry = files[key] || {};
+            return sum + (entry.size && entry.size > 0 ? entry.size : 0);
+        }, 0);
+    return {
+        totalBytes,
+        fileCount,
+        files,
+        updatedAt: manifest.updatedAt || Date.now(),
+    };
+}
+
+function recordHistory(sample) {
+    state.history.push(sample);
+    while (state.history.length > HISTORY_LIMIT) {
+        state.history.shift();
+    }
+}
+
+function enqueueEvent(event) {
+    if (!event) return;
+    state.events.push(event);
+    state.listeners.forEach(function(listener) {
+        try { listener(event); } catch (_) {}
+    });
+    signalWarningSemaphore();
+}
+
+function signalWarningSemaphore() {
+    if (!state.warningSemaphore) return;
+    const global = getGlobalObject();
+    const squeak = global.Squeak;
+    if (!squeak || !squeak.vm || !squeak.vm.primHandler ||
+        typeof squeak.vm.primHandler.signalSemaphoreWithIndex !== "function") {
+        return;
+    }
+    try {
+        squeak.vm.primHandler.signalSemaphoreWithIndex(state.warningSemaphore);
+    } catch (_) {}
+}
+
+function classifyFilePriority(path) {
+    if (!path || typeof path !== "string") return 5;
+    const lower = path.toLowerCase();
+    if (lower.endsWith(".image") || lower.endsWith(".changes") || lower.endsWith(".sources")) return 0;
+    if (lower.endsWith(".project") || lower.endsWith(".mcz") || lower.endsWith(".sar")) return 1;
+    if (lower.endsWith(".log") || lower.endsWith(".txt")) return 2;
+    if (lower.endsWith(".json") || lower.endsWith(".js")) return 3;
+    return 4;
+}
+
+function planEviction(estimate, manifestSummary) {
+    if (!state.evictionHandler || !manifestSummary || manifestSummary.fileCount === 0) {
+        return null;
+    }
+    const percentUsed = estimate.quota > 0 ? estimate.usage / estimate.quota : 0;
+    if (percentUsed < state.thresholds.critical) {
+        return null;
+    }
+    const targetBytes = Math.min(
+        estimate.usage,
+        Math.max(estimate.usage - estimate.quota * 0.7, estimate.quota * 0.1)
+    );
+    const entries = Object.keys(manifestSummary.files).map(function(path) {
+        const meta = manifestSummary.files[path] || {};
+        return {
+            path: path,
+            size: typeof meta.size === "number" && meta.size > 0 ? meta.size : 0,
+            updatedAt: typeof meta.updatedAt === "number" ? meta.updatedAt : 0,
+            priority: classifyFilePriority(path),
+        };
+    });
+    entries.sort(function(a, b) {
+        if (a.priority !== b.priority) return b.priority - a.priority;
+        return a.updatedAt - b.updatedAt;
+    });
+    let reclaimed = 0;
+    const selected = [];
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        if (entry.priority <= 0) continue;
+        selected.push(entry.path);
+        reclaimed += entry.size;
+        if (reclaimed >= targetBytes) break;
+    }
+    if (!selected.length) {
+        return null;
+    }
+    return {
+        targetBytes,
+        reclaimedEstimate: reclaimed,
+        paths: selected,
+        percentUsed,
+    };
+}
+
+function maybeTriggerEviction(estimate, manifestSummary) {
+    if (state.evictionInFlight || !state.evictionHandler) return;
+    const plan = planEviction(estimate, manifestSummary);
+    if (!plan) return;
+    state.evictionInFlight = true;
+    const result = state.evictionHandler(plan.paths, {
+        targetBytes: plan.targetBytes,
+        reclaimedEstimate: plan.reclaimedEstimate,
+        percentUsed: plan.percentUsed,
+    });
+    state.lastEviction = {
+        requestedAt: Date.now(),
+        plan,
+    };
+    Promise.resolve(result).catch(function(error) {
+        state.lastError = formatError(error);
+    }).finally(function() {
+        state.evictionInFlight = false;
+    });
+    enqueueEvent({
+        type: "eviction-request",
+        paths: plan.paths.slice(0),
+        targetBytes: plan.targetBytes,
+        reclaimedEstimate: plan.reclaimedEstimate,
+        percentUsed: plan.percentUsed,
+        timestamp: Date.now(),
+    });
+}
+
+function recordEvictionResult(result) {
+    const entry = Object.assign({ completedAt: Date.now() }, result || {});
+    state.lastEviction = Object.assign({}, state.lastEviction, { result: entry, completedAt: entry.completedAt });
+    enqueueEvent({
+        type: "eviction-result",
+        result: entry,
+        timestamp: entry.completedAt,
+    });
+}
+
+function formatError(error) {
+    if (!error) return null;
+    if (typeof error === "string") {
+        return { name: "Error", message: error };
+    }
+    const formatted = {
+        name: error && error.name ? error.name : "Error",
+        message: error && error.message ? error.message : String(error),
+    };
+    if (error.code !== undefined) formatted.code = error.code;
+    if (error.type !== undefined) formatted.type = error.type;
+    if (error.reason !== undefined) formatted.reason = error.reason;
+    return formatted;
+}
+
+function evaluateThresholds(sample) {
+    const percentUsed = sample.percentUsed;
+    const triggeredLevels = [];
+    Object.keys(state.thresholds).forEach(function(level) {
+        const threshold = state.thresholds[level];
+        if (typeof threshold !== "number") return;
+        const previously = state.lastLevels[level] || 0;
+        if (percentUsed >= threshold && previously < threshold) {
+            state.lastLevels[level] = percentUsed;
+            triggeredLevels.push(level);
+        } else if (percentUsed < threshold * 0.9) {
+            state.lastLevels[level] = percentUsed;
+        }
+    });
+    triggeredLevels.forEach(function(level) {
+        enqueueEvent({
+            type: "threshold", level: level,
+            percentUsed: sample.percentUsed,
+            usage: sample.usage,
+            quota: sample.quota,
+            cacheBytes: sample.cacheBytes,
+            timestamp: sample.timestamp,
+        });
+    });
+}
+
+function processEstimate(estimate, manifestSummary) {
+    const now = Date.now();
+    const sample = {
+        timestamp: now,
+        usage: estimate.usage,
+        quota: estimate.quota,
+        percentUsed: estimate.quota > 0 ? estimate.usage / estimate.quota : 0,
+        cacheBytes: manifestSummary.totalBytes,
+        fileCount: manifestSummary.fileCount,
+        persisted: !!estimate.persisted,
+    };
+    state.lastEstimate = sample;
+    recordHistory(sample);
+    evaluateThresholds(sample);
+    maybeTriggerEviction(estimate, manifestSummary);
+    return sample;
+}
+
+function ensureEstimateSupport() {
+    const global = getGlobalObject();
+    const navigatorObj = global.navigator;
+    state.storageEstimateSupported = !!(navigatorObj && navigatorObj.storage && typeof navigatorObj.storage.estimate === "function");
+    return state.storageEstimateSupported;
+}
+
+function ensureMonitor(options) {
+    options = options || {};
+    if (options.thresholds) setThresholds(options.thresholds);
+    if (options.pollInterval !== undefined) setPollInterval(options.pollInterval);
+    ensureEstimateSupport();
+    state.monitorStarted = true;
+    if (options.listener && typeof options.listener === "function") {
+        registerListener(options.listener);
+    }
+    if (options.autoSample !== false) {
+        if (options.immediate !== false) {
+            forceSample();
+        }
+        if (state.pollInterval > 0) {
+            scheduleNextSample(state.pollInterval);
+        }
+    }
+    return getState();
+}
+
+function registerListener(listener) {
+    if (typeof listener === "function") {
+        state.listeners.push(listener);
+    }
+    return function unsubscribe() {
+        const index = state.listeners.indexOf(listener);
+        if (index !== -1) state.listeners.splice(index, 1);
+    };
+}
+
+function setWarningSemaphore(index) {
+    if (typeof index === "number" && index > 0) {
+        state.warningSemaphore = index;
+        return index;
+    }
+    state.warningSemaphore = null;
+    return null;
+}
+
+function updateManifest(manifest) {
+    state.manifestSummary = summarizeManifest(manifest);
+}
+
+function setVFSSupport(supported) {
+    state.supported = !!supported;
+}
+
+function setEvictionHandler(handler) {
+    if (typeof handler === "function") {
+        state.evictionHandler = handler;
+    } else {
+        state.evictionHandler = null;
+    }
+}
+
+function drainEvents() {
+    const drained = state.events.splice(0, state.events.length);
+    return drained;
+}
+
+function getState() {
+    return {
+        monitorStarted: state.monitorStarted,
+        thresholds: Object.assign({}, state.thresholds),
+        pollInterval: state.pollInterval,
+        history: state.history.slice(0),
+        events: state.events.slice(0),
+        lastEstimate: state.lastEstimate,
+        manifest: Object.assign({}, state.manifestSummary),
+        supported: state.supported,
+        storageEstimateSupported: state.storageEstimateSupported,
+        lastError: state.lastError,
+        lastEviction: state.lastEviction,
+    };
+}
+
+function forceSample() {
+    if (state.sampleInFlight) return state.sampleInFlight;
+    ensureEstimateSupport();
+    const manifestSummary = state.manifestSummary;
+    const global = getGlobalObject();
+    const navigatorObj = global.navigator;
+    let estimatePromise;
+    if (state.storageEstimateSupported) {
+        try {
+            estimatePromise = Promise.resolve(navigatorObj.storage.estimate());
+        } catch (error) {
+            state.lastError = formatError(error);
+            estimatePromise = Promise.resolve({ usage: manifestSummary.totalBytes, quota: manifestSummary.totalBytes });
+        }
+    } else {
+        estimatePromise = Promise.resolve({ usage: manifestSummary.totalBytes, quota: manifestSummary.totalBytes });
+    }
+    state.sampleInFlight = estimatePromise.then(function(estimate) {
+        const normalized = normalizeEstimate(estimate || {}, manifestSummary);
+        const sample = processEstimate(normalized, manifestSummary);
+        return sample;
+    }).catch(function(error) {
+        state.lastError = formatError(error);
+        const fallback = normalizeEstimate({}, manifestSummary);
+        return processEstimate(fallback, manifestSummary);
+    }).finally(function() {
+        state.sampleInFlight = null;
+        if (state.pollInterval > 0 && !state.pendingTimer) {
+            scheduleNextSample(state.pollInterval);
+        }
+    });
+    return state.sampleInFlight;
+}
+
+function drainEventsAsJSON() {
+    const events = drainEvents();
+    try {
+        return JSON.stringify(events);
+    } catch (_) {
+        return "[]";
+    }
+}
+
+const namespace = ensureQuotaNamespace();
+namespace.ensureMonitor = ensureMonitor;
+namespace.getState = getState;
+namespace.forceSample = forceSample;
+namespace.drainEvents = drainEvents;
+namespace.setWarningSemaphore = setWarningSemaphore;
+namespace.updateManifest = updateManifest;
+namespace.setVFSSupport = setVFSSupport;
+namespace.setEvictionHandler = setEvictionHandler;
+namespace.recordEvictionResult = recordEvictionResult;
+
+export {
+    ensureMonitor as ensureStorageQuotaMonitor,
+    getState as getStorageQuotaState,
+    forceSample as forceStorageQuotaSample,
+    drainEvents as drainStorageQuotaEvents,
+    drainEventsAsJSON,
+    setWarningSemaphore as setStorageQuotaWarningSemaphore,
+    updateManifest as updateStorageQuotaManifest,
+    setVFSSupport as setStorageQuotaVFSSupport,
+    setEvictionHandler as setStorageQuotaEvictionHandler,
+    recordEvictionResult as recordStorageQuotaEvictionResult,
+};
+

--- a/vm.storage.vfs.js
+++ b/vm.storage.vfs.js
@@ -1,0 +1,400 @@
+import { updateStorageQuotaManifest, setStorageQuotaVFSSupport, setStorageQuotaEvictionHandler, recordStorageQuotaEvictionResult } from "./vm.storage.quota.js";
+
+"use strict";
+
+const DEFAULT_SCOPE = "./";
+const DEFAULT_SCRIPT_URL = "./run/squeak-storage-sw.js";
+const DEFAULT_CACHE_NAME = "squeak-vfs-cache";
+const STORAGE_CHANNEL = "squeak-storage-vfs";
+const VFS_URL_PREFIX = "https://squeak.invalid/vfs/";
+
+const state = {
+    supported: false,
+    controller: null,
+    registrationAttempted: false,
+    registrationScope: null,
+    registrationUrl: null,
+    registrationError: null,
+    cacheName: DEFAULT_CACHE_NAME,
+    pending: [],
+    sequence: 0,
+    lastFlushAt: null,
+    lastOperationAt: null,
+    queuedOperations: 0,
+    manifest: null,
+    replay: {
+        lastRun: null,
+        restored: 0,
+        errors: 0,
+        lastError: null,
+    },
+};
+
+let registrationPromise = null;
+let readyRegistration = null;
+let suppressNotifications = false;
+
+function getGlobalObject() {
+    if (typeof globalThis !== "undefined") return globalThis;
+    if (typeof self !== "undefined") return self;
+    if (typeof window !== "undefined") return window;
+    if (typeof global !== "undefined") return global;
+    return {};
+}
+
+function ensureSqueakNamespace() {
+    const global = getGlobalObject();
+    if (!global.Squeak) global.Squeak = {};
+    if (!global.Squeak.StorageVFS) {
+        global.Squeak.StorageVFS = {};
+    }
+    return global.Squeak.StorageVFS;
+}
+
+function nowTimestamp() {
+    return typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+}
+
+function formatError(error) {
+    if (!error) return null;
+    if (typeof error === "string") {
+        return { name: "Error", message: error };
+    }
+    const formatted = {
+        name: typeof error.name === "string" && error.name ? error.name : "Error",
+        message: typeof error.message === "string" && error.message ? error.message : String(error),
+    };
+    if (error.code !== undefined) formatted.code = error.code;
+    if (error.type !== undefined) formatted.type = error.type;
+    if (error.stack) formatted.stack = String(error.stack);
+    return formatted;
+}
+
+function cloneBuffer(data) {
+    if (!data) return null;
+    if (data instanceof ArrayBuffer) {
+        return data.slice(0);
+    }
+    if (ArrayBuffer.isView(data)) {
+        const view = data;
+        return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+    }
+    if (typeof data === "string") {
+        const encoder = typeof TextEncoder !== "undefined" ? new TextEncoder() : null;
+        return encoder ? encoder.encode(data).buffer : null;
+    }
+    return null;
+}
+
+function supportsServiceWorker() {
+    const global = getGlobalObject();
+    const navigatorObj = global.navigator;
+    if (!navigatorObj || !navigatorObj.serviceWorker) return false;
+    if (typeof global.caches === "undefined") return false;
+    return true;
+}
+
+function updateController(controller) {
+    state.controller = controller || null;
+    flushPendingOperations();
+}
+
+function listenForControllerChanges() {
+    const global = getGlobalObject();
+    if (!global.navigator || !global.navigator.serviceWorker) return;
+    try {
+        global.navigator.serviceWorker.addEventListener("controllerchange", function onControllerChange() {
+            updateController(global.navigator.serviceWorker.controller || null);
+        });
+    } catch (_) {}
+}
+
+function postMessageToWorker(message, transferables) {
+    if (!state.controller) return false;
+    try {
+        if (typeof state.controller.postMessage === "function") {
+            state.controller.postMessage(message, transferables || []);
+            return true;
+        }
+    } catch (error) {
+        state.registrationError = formatError(error);
+    }
+    return false;
+}
+
+function flushPendingOperations() {
+    if (!state.pending.length) return;
+    if (!state.controller && readyRegistration && readyRegistration.active) {
+        state.controller = readyRegistration.active;
+    }
+    if (!state.controller) return;
+    const toSend = state.pending.splice(0, state.pending.length);
+    state.queuedOperations = state.pending.length;
+    toSend.forEach(function(op) {
+        const transfer = [];
+        if (op.contents instanceof ArrayBuffer) transfer.push(op.contents);
+        postMessageToWorker(op, transfer);
+    });
+    state.lastFlushAt = nowTimestamp();
+}
+
+function enqueueOperation(operation) {
+    state.lastOperationAt = nowTimestamp();
+    if (!state.supported || suppressNotifications) return;
+    operation.channel = STORAGE_CHANNEL;
+    operation.cacheName = state.cacheName;
+    operation.sequence = ++state.sequence;
+    state.pending.push(operation);
+    state.queuedOperations = state.pending.length;
+    flushPendingOperations();
+}
+
+function enqueueEviction(paths, metadata) {
+    if (!Array.isArray(paths) || !paths.length) return;
+    const payload = Object.assign({
+        operation: "evict",
+        paths: paths,
+    }, metadata || {});
+    enqueueOperation(payload);
+}
+
+function handleServiceWorkerMessage(event) {
+    const data = event && event.data;
+    if (!data || data.channel !== STORAGE_CHANNEL) return;
+    if (data.type === "manifest") {
+        state.manifest = data.manifest || null;
+        updateStorageQuotaManifest(state.manifest);
+    } else if (data.type === "replay-result") {
+        if (data.restored !== undefined) state.replay.restored = data.restored;
+        if (data.errors !== undefined) state.replay.errors = data.errors;
+        if (data.lastError) state.replay.lastError = data.lastError;
+        if (data.timestamp) state.replay.lastRun = data.timestamp;
+    } else if (data.type === "eviction-result") {
+        recordStorageQuotaEvictionResult({
+            paths: Array.isArray(data.paths) ? data.paths : [],
+            reclaimedBytes: typeof data.reclaimedBytes === "number" ? data.reclaimedBytes : 0,
+            errors: Array.isArray(data.errors) ? data.errors : [],
+            timestamp: data.timestamp || Date.now(),
+            cacheName: data.cacheName || state.cacheName,
+        });
+        if (data.manifest) {
+            state.manifest = data.manifest;
+            updateStorageQuotaManifest(state.manifest);
+        }
+    }
+}
+
+function ensureMessageListener() {
+    const global = getGlobalObject();
+    const navigatorObj = global.navigator;
+    if (!navigatorObj || !navigatorObj.serviceWorker) return;
+    if (typeof navigatorObj.serviceWorker.addEventListener === "function") {
+        try {
+            navigatorObj.serviceWorker.addEventListener("message", handleServiceWorkerMessage);
+        } catch (_) {}
+    }
+}
+
+async function ensureStorageVFSRegistration(options) {
+    options = options || {};
+    const global = getGlobalObject();
+    const navigatorObj = global.navigator;
+    state.cacheName = options.cacheName || state.cacheName || DEFAULT_CACHE_NAME;
+    if (!state.registrationAttempted) {
+        state.supported = supportsServiceWorker();
+        setStorageQuotaVFSSupport(state.supported);
+        state.registrationAttempted = true;
+        ensureMessageListener();
+        listenForControllerChanges();
+    }
+    if (!state.supported || !navigatorObj || !navigatorObj.serviceWorker) {
+        setStorageQuotaVFSSupport(state.supported);
+        return null;
+    }
+    if (registrationPromise) {
+        return registrationPromise;
+    }
+    const scriptURL = options.scriptURL || DEFAULT_SCRIPT_URL;
+    const scope = options.scope || DEFAULT_SCOPE;
+    state.registrationUrl = scriptURL;
+    state.registrationScope = scope;
+    registrationPromise = navigatorObj.serviceWorker.register(scriptURL, { scope: scope }).then(function(reg) {
+        readyRegistration = reg;
+        updateController(navigatorObj.serviceWorker.controller || reg.active || null);
+        return navigatorObj.serviceWorker.ready.catch(function() { return reg; }).then(function(ready) {
+            readyRegistration = ready || reg;
+            updateController(navigatorObj.serviceWorker.controller || (readyRegistration && readyRegistration.active) || null);
+            return ready;
+        });
+    }).then(function(reg) {
+        if (options.autoReplay !== false) {
+            return replayFromCache().catch(function(error) {
+                state.replay.lastError = formatError(error);
+                return null;
+            }).then(function() { return reg; });
+        }
+        return reg;
+    }).catch(function(error) {
+        state.registrationError = formatError(error);
+        registrationPromise = null;
+        throw error;
+    });
+    return registrationPromise;
+}
+
+function notifyWrite(path, contents, metadata) {
+    if (!path) return;
+    const buffer = cloneBuffer(contents);
+    enqueueOperation({
+        operation: "write",
+        path: path,
+        contents: buffer,
+        size: metadata && metadata.size !== undefined ? metadata.size : (buffer ? buffer.byteLength : 0),
+        updatedAt: metadata && metadata.updatedAt !== undefined ? metadata.updatedAt : Date.now(),
+        directory: metadata && metadata.directory ? metadata.directory : null,
+    });
+}
+
+function notifyDelete(path, metadata) {
+    if (!path) return;
+    enqueueOperation({
+        operation: "delete",
+        path: path,
+        updatedAt: metadata && metadata.updatedAt !== undefined ? metadata.updatedAt : Date.now(),
+        directory: metadata && metadata.directory ? metadata.directory : null,
+    });
+}
+
+function notifyRename(fromPath, toPath, options) {
+    if (!fromPath || !toPath) return;
+    const buffer = options && options.contents ? cloneBuffer(options.contents) : null;
+    enqueueOperation({
+        operation: "rename",
+        fromPath: fromPath,
+        toPath: toPath,
+        contents: buffer,
+        size: options && options.size !== undefined ? options.size : (buffer ? buffer.byteLength : 0),
+        updatedAt: options && options.updatedAt !== undefined ? options.updatedAt : Date.now(),
+        directory: options && options.directory ? options.directory : null,
+    });
+}
+
+async function replayFromCache(options) {
+    options = options || {};
+    if (!state.supported) return { restored: 0, errors: 0, skipped: true };
+    const cacheName = options.cacheName || state.cacheName || DEFAULT_CACHE_NAME;
+    let cache;
+    try {
+        cache = await caches.open(cacheName);
+    } catch (error) {
+        state.replay.lastError = formatError(error);
+        throw error;
+    }
+    let requests;
+    try {
+        requests = await cache.keys();
+    } catch (error) {
+        state.replay.lastError = formatError(error);
+        throw error;
+    }
+    let restored = 0;
+    let errors = 0;
+    const SqueakVFS = ensureSqueakNamespace();
+    const SqueakGlobal = getGlobalObject().Squeak;
+    suppressNotifications = true;
+    try {
+        for (let i = 0; i < requests.length; i++) {
+            const request = requests[i];
+            if (!request || typeof request.url !== "string") continue;
+            if (!request.url.startsWith(VFS_URL_PREFIX)) continue;
+            if (request.url.endsWith("__manifest__")) continue;
+            if (request.url.indexOf("?temp=") !== -1) continue;
+            const response = await cache.match(request);
+            if (!response) continue;
+            let buffer;
+            try {
+                buffer = await response.arrayBuffer();
+            } catch (error) {
+                errors++;
+                state.replay.lastError = formatError(error);
+                continue;
+            }
+            const encodedPath = request.url.substring(VFS_URL_PREFIX.length);
+            let path;
+            try {
+                path = decodeURIComponent(encodedPath);
+            } catch (_) {
+                path = encodedPath;
+            }
+            if (!SqueakGlobal || typeof SqueakGlobal.filePut !== "function") {
+                continue;
+            }
+            try {
+                SqueakGlobal.filePut(path, buffer);
+                restored++;
+            } catch (error) {
+                errors++;
+                state.replay.lastError = formatError(error);
+            }
+        }
+    } finally {
+        suppressNotifications = false;
+    }
+    state.replay.restored = restored;
+    state.replay.errors = errors;
+    state.replay.lastRun = Date.now();
+    if (SqueakVFS) {
+        SqueakVFS.lastReplay = {
+            restored: restored,
+            errors: errors,
+            timestamp: state.replay.lastRun,
+        };
+    }
+    return { restored: restored, errors: errors };
+}
+
+function getStateSnapshot() {
+    return {
+        supported: state.supported,
+        registrationAttempted: state.registrationAttempted,
+        registrationScope: state.registrationScope,
+        registrationUrl: state.registrationUrl,
+        registrationError: state.registrationError,
+        cacheName: state.cacheName,
+        pending: state.pending.length,
+        sequence: state.sequence,
+        lastFlushAt: state.lastFlushAt,
+        lastOperationAt: state.lastOperationAt,
+        manifest: state.manifest,
+        replay: Object.assign({}, state.replay),
+    };
+}
+
+const StorageVFS = ensureSqueakNamespace();
+StorageVFS.ensureRegistration = ensureStorageVFSRegistration;
+StorageVFS.notifyWrite = notifyWrite;
+StorageVFS.notifyDelete = notifyDelete;
+StorageVFS.notifyRename = notifyRename;
+StorageVFS.replayFromCache = replayFromCache;
+StorageVFS.getState = getStateSnapshot;
+StorageVFS.isSupported = function() { return state.supported; };
+
+setStorageQuotaEvictionHandler(function(paths, metadata) {
+    enqueueEviction(paths, {
+        requestedBytes: metadata && metadata.targetBytes,
+        reclaimedEstimate: metadata && metadata.reclaimedEstimate,
+        percentUsed: metadata && metadata.percentUsed,
+    });
+});
+
+export {
+    ensureStorageVFSRegistration,
+    notifyWrite as notifyStorageWrite,
+    notifyDelete as notifyStorageDelete,
+    notifyRename as notifyStorageRename,
+    replayFromCache as replayStorageFromCache,
+    getStateSnapshot as getStorageVFSState,
+};
+

--- a/vm.worker.entry.js
+++ b/vm.worker.entry.js
@@ -129,6 +129,105 @@ function createDisplay(options) {
         devicePixelRatio: options.devicePixelRatio && options.devicePixelRatio > 0 ? options.devicePixelRatio : 1,
     };
 
+    function createClipboardState() {
+        return {
+            text: "",
+            cachedAt: null,
+            lastRead: null,
+            lastWrite: null,
+            lastStatus: null,
+            lastError: null,
+            permission: {
+                read: { state: "unknown", updatedAt: null },
+                write: { state: "unknown", updatedAt: null },
+            },
+            staleDrops: 0,
+            errorCounts: {},
+            queue: { pending: 0, last: null },
+        };
+    }
+
+    function mergeClipboardPermission(target, source) {
+        if (!target || !source || typeof source !== "object") return;
+        if (!target.read) target.read = {};
+        if (!target.write) target.write = {};
+        if (source.read && typeof source.read === "object") {
+            Object.keys(source.read).forEach(function(key) {
+                target.read[key] = source.read[key];
+            });
+        }
+        if (source.write && typeof source.write === "object") {
+            Object.keys(source.write).forEach(function(key) {
+                target.write[key] = source.write[key];
+            });
+        }
+    }
+
+    display.clipboardState = createClipboardState();
+
+    display.updateClipboardState = function(partial) {
+        if (!partial || typeof partial !== "object") return display.clipboardState;
+        if (partial.state && typeof partial.state === "object" && partial.state !== partial) {
+            display.updateClipboardState(partial.state);
+        }
+        if (partial.cachedText !== undefined && typeof partial.cachedText === "string") {
+            display.clipboardState.text = partial.cachedText;
+        }
+        if (partial.text !== undefined && typeof partial.text === "string") {
+            display.clipboardState.text = partial.text;
+        }
+        if (partial.cachedAt !== undefined) display.clipboardState.cachedAt = partial.cachedAt;
+        if (partial.lastRead !== undefined) display.clipboardState.lastRead = partial.lastRead;
+        if (partial.lastWrite !== undefined) display.clipboardState.lastWrite = partial.lastWrite;
+        if (partial.lastStatus !== undefined) display.clipboardState.lastStatus = partial.lastStatus;
+        if (partial.lastErrorDetail !== undefined) display.clipboardState.lastError = partial.lastErrorDetail;
+        if (partial.lastError !== undefined && typeof partial.lastError === "object") {
+            display.clipboardState.lastError = Object.assign({}, partial.lastError);
+        }
+        if (partial.permissionDetail) mergeClipboardPermission(display.clipboardState.permission, partial.permissionDetail);
+        if (partial.permission && typeof partial.permission === "object" && !Array.isArray(partial.permission)) {
+            mergeClipboardPermission(display.clipboardState.permission, partial.permission);
+        }
+        if (partial.staleDrops !== undefined) display.clipboardState.staleDrops = partial.staleDrops;
+        if (partial.errorCounts && typeof partial.errorCounts === "object") {
+            display.clipboardState.errorCounts = Object.assign({}, partial.errorCounts);
+        }
+        if (partial.queue && typeof partial.queue === "object") {
+            display.clipboardState.queue = {
+                pending: partial.queue.pending || 0,
+                last: partial.queue.last ? Object.assign({}, partial.queue.last) : null,
+            };
+        }
+        if (partial.queueState && typeof partial.queueState === "object") {
+            display.clipboardState.queue = {
+                pending: partial.queueState.pending || 0,
+                last: partial.queueState.last ? Object.assign({}, partial.queueState.last) : null,
+            };
+        }
+        if (partial.lastStatus && typeof partial.lastStatus === "object") {
+            display.clipboardState.lastStatus = partial.lastStatus;
+        }
+        return display.clipboardState;
+    };
+
+    display.getClipboardDiagnostics = function() {
+        return {
+            text: display.clipboardState.text || "",
+            cachedAt: display.clipboardState.cachedAt,
+            lastRead: display.clipboardState.lastRead,
+            lastWrite: display.clipboardState.lastWrite,
+            permission: {
+                read: Object.assign({}, display.clipboardState.permission.read || {}),
+                write: Object.assign({}, display.clipboardState.permission.write || {}),
+            },
+            staleDrops: display.clipboardState.staleDrops,
+            errorCounts: Object.assign({}, display.clipboardState.errorCounts || {}),
+            queue: Object.assign({ pending: 0, last: null }, display.clipboardState.queue || {}),
+            lastStatus: display.clipboardState.lastStatus,
+            lastError: display.clipboardState.lastError,
+        };
+    };
+
     display.reset = function() {
         display.keys = [];
         display.buttons = 0;
@@ -136,22 +235,37 @@ function createDisplay(options) {
         display.eventQueue = [];
         display.eventQueueOffset = null;
         display.signalInputEvent = null;
+        display.clipboardState = createClipboardState();
     };
 
     display.readFromSystemClipboard = function() {
         return handleClipboardReadRequest().then(function(payload) {
-            if (!payload || typeof payload.text !== "string") return;
-            display.clipboardString = payload.text;
-            display.clipboardStringChanged = false;
-            return payload.text;
+            display.lastClipboardPayload = payload || null;
+            if (payload && typeof payload.text === "string") {
+                display.clipboardString = payload.text;
+                display.clipboardStringChanged = false;
+            }
+            if (payload && payload.error) {
+                display.clipboardLastError = payload.error;
+            }
+            if (payload && typeof payload === "object") {
+                display.updateClipboardState(payload.state || payload);
+            }
+            return payload;
         });
     };
 
     display.writeToSystemClipboard = function() {
         var text = typeof display.clipboardString === "string" ? display.clipboardString : "";
-        return handleClipboardWriteRequest(text).then(function() {
-            display.clipboardStringChanged = false;
-            return text;
+        return handleClipboardWriteRequest(text).then(function(payload) {
+            display.lastClipboardPayload = payload || null;
+            if (!payload || !payload.error) {
+                display.clipboardStringChanged = false;
+            }
+            if (payload && typeof payload === "object") {
+                display.updateClipboardState(payload.state || payload);
+            }
+            return payload;
         });
     };
 
@@ -372,10 +486,18 @@ port.onmessage = function(event) {
             if (workerState.display) {
                 workerState.display.clipboardString = data.text || "";
                 workerState.display.clipboardStringChanged = !!data.changed;
+                workerState.display.updateClipboardState({
+                    text: data.text || "",
+                    cachedAt: typeof data.timestamp === "number" ? data.timestamp : undefined,
+                    lastWrite: typeof data.timestamp === "number" ? data.timestamp : undefined,
+                });
             }
             break;
         case "clipboard-read-response":
         case "clipboard-write-response":
+            if (workerState.display && data && typeof data === "object") {
+                workerState.display.updateClipboardState(data.state || data);
+            }
             var resolver = clipboardRequests.get(data.requestId);
             if (resolver) {
                 clipboardRequests.delete(data.requestId);

--- a/vm.worker.host.js
+++ b/vm.worker.host.js
@@ -1,8 +1,10 @@
 "use strict";
 
 import { ensureStorageCapabilityReport, setStorageCapabilityReport, getStorageCapabilityReport } from "./vm.storage.capabilities.js";
+import { createClipboardBridge, createClipboardRequestQueue } from "./vm.clipboard.js";
 
 const defaultWorkerURL = new URL("./vm.worker.entry.js", import.meta.url);
+const GESTURE_WINDOW_MS = 1200;
 
 function normalizeBuffer(source) {
     if (source instanceof ArrayBuffer) return source;
@@ -32,12 +34,57 @@ export class WorkerVMController {
         };
         this._clipboardState = {
             text: "",
-            lastUpdate: 0,
+            cachedAt: null,
+            lastRead: null,
+            lastWrite: null,
+            lastStatus: null,
+            lastError: null,
+            permission: {
+                read: { state: "unknown", updatedAt: null },
+                write: { state: "unknown", updatedAt: null },
+            },
+            staleDrops: 0,
+            errorCounts: {},
+            metricsKey: null,
+            metricsUpdatedAt: null,
+            queueState: null,
         };
+        this._clipboardBridge = createClipboardBridge({
+            getUserGesture: () => this._isGestureActive(),
+            onStatus: (status) => this._recordClipboardStatus(status),
+        });
+        this._syncClipboardStateFromBridge();
+        var controller = this;
+        this._clipboardQueue = createClipboardRequestQueue({
+            read: function(options) {
+                var requestOptions = Object.assign({ fallbackToCache: true }, options || {});
+                if (requestOptions.requireGesture === undefined) {
+                    requestOptions.requireGesture = controller._isGestureActive();
+                }
+                if (!controller._clipboardBridge || typeof controller._clipboardBridge.readText !== "function") {
+                    var cachedText = typeof controller._clipboardState.text === "string"
+                        ? controller._clipboardState.text
+                        : "";
+                    return Promise.resolve({ text: cachedText, fromCache: true, permission: "unknown" });
+                }
+                return controller._clipboardBridge.readText(requestOptions);
+            },
+            write: function(text, options) {
+                var requestOptions = Object.assign({}, options || {});
+                if (requestOptions.requireGesture === undefined) {
+                    requestOptions.requireGesture = controller._isGestureActive();
+                }
+                if (!controller._clipboardBridge || typeof controller._clipboardBridge.writeText !== "function") {
+                    return Promise.resolve({ text: text, fromCache: true, permission: "unknown" });
+                }
+                return controller._clipboardBridge.writeText(text, requestOptions);
+            },
+        });
         this._pendingClipboard = new Map();
         this._pendingReports = new Map();
         this._nextReportId = 1;
         this._lastFeatureReport = null;
+        this._lastGestureAt = 0;
     }
 
     on(type, handler) {
@@ -66,6 +113,78 @@ export class WorkerVMController {
                 }
             }
         });
+    }
+
+    _recordClipboardStatus(status) {
+        this._clipboardState.lastStatus = status || null;
+        this._syncClipboardStateFromBridge();
+        this.emit("clipboard-status", status);
+    }
+
+    _syncClipboardStateFromBridge(snapshot) {
+        if (!snapshot && this._clipboardBridge && typeof this._clipboardBridge.getState === "function") {
+            snapshot = this._clipboardBridge.getState();
+        }
+        if (!snapshot || typeof snapshot !== "object") return;
+        if (typeof snapshot.cachedText === "string") this._clipboardState.text = snapshot.cachedText;
+        if (snapshot.cachedAt !== undefined) this._clipboardState.cachedAt = snapshot.cachedAt;
+        if (snapshot.lastRead !== undefined) this._clipboardState.lastRead = snapshot.lastRead;
+        if (snapshot.lastWrite !== undefined) this._clipboardState.lastWrite = snapshot.lastWrite;
+        if (snapshot.lastStatus !== undefined) this._clipboardState.lastStatus = snapshot.lastStatus;
+        if (snapshot.lastError !== undefined) this._clipboardState.lastError = snapshot.lastError ? Object.assign({}, snapshot.lastError) : null;
+        if (snapshot.permission !== undefined) {
+            this._clipboardState.permission = {
+                read: Object.assign({}, snapshot.permission.read || {}),
+                write: Object.assign({}, snapshot.permission.write || {}),
+            };
+        }
+        if (snapshot.errorCounts !== undefined) this._clipboardState.errorCounts = Object.assign({}, snapshot.errorCounts);
+        if (snapshot.staleDrops !== undefined) this._clipboardState.staleDrops = snapshot.staleDrops;
+        if (snapshot.metricsKey !== undefined) this._clipboardState.metricsKey = snapshot.metricsKey;
+        if (snapshot.metricsUpdatedAt !== undefined) this._clipboardState.metricsUpdatedAt = snapshot.metricsUpdatedAt;
+    }
+
+    getClipboardDiagnostics() {
+        this._syncClipboardStateFromBridge();
+        var queueState = this._clipboardQueue && typeof this._clipboardQueue.getState === "function"
+            ? this._clipboardQueue.getState()
+            : (this._clipboardState.queueState || { pending: 0, last: null });
+        this._clipboardState.queueState = queueState;
+        var permissions = this._clipboardState.permission || { read: { state: "unknown" }, write: { state: "unknown" } };
+        var preview = this._clipboardState.text || "";
+        if (preview.length > 120) preview = preview.slice(0, 117) + "...";
+        return {
+            text: this._clipboardState.text || "",
+            preview: preview,
+            cachedAt: this._clipboardState.cachedAt,
+            lastRead: this._clipboardState.lastRead,
+            lastWrite: this._clipboardState.lastWrite,
+            permissions: {
+                read: permissions.read && permissions.read.state ? permissions.read.state : "unknown",
+                write: permissions.write && permissions.write.state ? permissions.write.state : "unknown",
+            },
+            permissionDetail: {
+                read: Object.assign({}, permissions.read || {}),
+                write: Object.assign({}, permissions.write || {}),
+            },
+            queuePending: queueState.pending || 0,
+            queueLast: queueState.last || null,
+            lastStatus: this._clipboardState.lastStatus || null,
+            lastError: this._clipboardState.lastError || null,
+            staleDrops: this._clipboardState.staleDrops || 0,
+            errorCounts: Object.assign({}, this._clipboardState.errorCounts || {}),
+            metricsKey: this._clipboardState.metricsKey || null,
+            metricsUpdatedAt: this._clipboardState.metricsUpdatedAt || null,
+        };
+    }
+
+    _markGesture() {
+        this._lastGestureAt = Date.now();
+    }
+
+    _isGestureActive() {
+        if (!this._lastGestureAt) return false;
+        return Date.now() - this._lastGestureAt < GESTURE_WINDOW_MS;
     }
 
     async _ensureWorker() {
@@ -118,8 +237,15 @@ export class WorkerVMController {
         }
         if (data.type === "clipboard-set") {
             if (typeof data.text === "string") {
-                this._clipboardState.text = data.text;
-                this._clipboardState.lastUpdate = Date.now();
+                var timestamp = typeof data.timestamp === "number" && isFinite(data.timestamp) ? data.timestamp : Date.now();
+                if (this._clipboardBridge) {
+                    this._clipboardBridge.setCachedText(data.text, timestamp);
+                    this._syncClipboardStateFromBridge();
+                } else {
+                    this._clipboardState.text = data.text;
+                    this._clipboardState.cachedAt = timestamp;
+                }
+                this._clipboardState.lastWrite = timestamp;
             }
         }
         if (data.type === "clipboard-read-request" || data.type === "clipboard-write-request") {
@@ -182,44 +308,114 @@ export class WorkerVMController {
         var type = data.type;
         if (type === "clipboard-read-request") {
             var requestId = data.requestId;
-            var respond = function(payload) {
-                controller.worker.postMessage(Object.assign({
-                    type: "clipboard-read-response",
-                    requestId: requestId,
-                }, payload || {}));
-            };
-            if (typeof navigator !== "undefined" && navigator.clipboard && typeof navigator.clipboard.readText === "function") {
-                navigator.clipboard.readText().then(function(text) {
-                    controller._clipboardState.text = text;
-                    controller._clipboardState.lastUpdate = Date.now();
-                    respond({ text: text });
-                }).catch(function(error) {
-                    respond({ error: error && error.message ? error.message : String(error), text: controller._clipboardState.text });
+            var basePayload = { type: "clipboard-read-response", requestId: requestId };
+            var handler = this._clipboardQueue.enqueueRead({ fallbackToCache: true });
+            handler.then(function(result) {
+                var payload = result && typeof result === "object" ? Object.assign({}, result) : {};
+                var text = typeof payload.text === "string"
+                    ? payload.text
+                    : (controller._clipboardBridge ? controller._clipboardBridge.getCachedText() : controller._clipboardState.text);
+                if (typeof text !== "string") text = "";
+                payload.text = text;
+                controller._syncClipboardStateFromBridge(result && typeof result === "object" ? result.state : null);
+                controller._clipboardState.text = text;
+                controller._clipboardState.queueState = controller._clipboardQueue.getState();
+                payload.cachedAt = controller._clipboardState.cachedAt;
+                payload.lastRead = controller._clipboardState.lastRead;
+                payload.lastWrite = controller._clipboardState.lastWrite;
+                payload.staleDrops = controller._clipboardState.staleDrops;
+                payload.errorCounts = Object.assign({}, controller._clipboardState.errorCounts || {});
+                payload.permissionDetail = controller._clipboardState.permission;
+                payload.queueState = controller._clipboardState.queueState;
+                if (!payload.state && controller._clipboardBridge && typeof controller._clipboardBridge.getState === "function") {
+                    payload.state = controller._clipboardBridge.getState();
+                }
+                var response = Object.assign({}, basePayload, payload);
+                controller.worker.postMessage(response);
+            }).catch(function(error) {
+                var cachedText = controller._clipboardBridge ? controller._clipboardBridge.getCachedText() : controller._clipboardState.text;
+                if (typeof cachedText !== "string") cachedText = "";
+                controller._clipboardState.text = cachedText;
+                controller._syncClipboardStateFromBridge();
+                controller._clipboardState.queueState = controller._clipboardQueue.getState();
+                var permissionState = controller._clipboardState.permission && controller._clipboardState.permission.read
+                    ? controller._clipboardState.permission.read.state
+                    : "unknown";
+                var formatted = error && error.message ? { name: error.name || "Error", message: error.message } : null;
+                var response = Object.assign({}, basePayload, {
+                    text: cachedText,
+                    fromCache: true,
+                    permission: permissionState,
+                    cachedAt: controller._clipboardState.cachedAt,
+                    lastRead: controller._clipboardState.lastRead,
+                    lastWrite: controller._clipboardState.lastWrite,
+                    staleDrops: controller._clipboardState.staleDrops,
+                    errorCounts: Object.assign({}, controller._clipboardState.errorCounts || {}),
+                    permissionDetail: controller._clipboardState.permission,
+                    queueState: controller._clipboardState.queueState,
+                    state: controller._clipboardBridge && typeof controller._clipboardBridge.getState === "function"
+                        ? controller._clipboardBridge.getState()
+                        : null,
                 });
-            } else {
-                respond({ text: controller._clipboardState.text });
-            }
+                if (formatted) response.error = formatted;
+                controller.worker.postMessage(response);
+            });
             return;
         }
         if (type === "clipboard-write-request") {
             var text = typeof data.text === "string" ? data.text : "";
+            var timestamp = Date.now();
             this._clipboardState.text = text;
-            this._clipboardState.lastUpdate = Date.now();
-            var respondWrite = function(payload) {
-                controller.worker.postMessage(Object.assign({
-                    type: "clipboard-write-response",
-                    requestId: data.requestId,
-                }, payload || {}));
-            };
-            if (typeof navigator !== "undefined" && navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
-                navigator.clipboard.writeText(text).then(function() {
-                    respondWrite({ text: text });
-                }).catch(function(error) {
-                    respondWrite({ error: error && error.message ? error.message : String(error), text: text });
-                });
-            } else {
-                respondWrite({ text: text });
+            this._clipboardState.cachedAt = timestamp;
+            this._clipboardState.lastWrite = timestamp;
+            if (this._clipboardBridge) {
+                this._clipboardBridge.setCachedText(text, timestamp);
+                this._syncClipboardStateFromBridge();
             }
+            var basePayload = { type: "clipboard-write-response", requestId: data.requestId };
+            var writePromise = this._clipboardQueue.enqueueWrite(text, {});
+            writePromise.then(function(result) {
+                var payload = result && typeof result === "object" ? Object.assign({}, result) : {};
+                if (payload.text === undefined) payload.text = text;
+                controller._syncClipboardStateFromBridge(result && typeof result === "object" ? result.state : null);
+                controller._clipboardState.queueState = controller._clipboardQueue.getState();
+                payload.cachedAt = controller._clipboardState.cachedAt;
+                payload.lastRead = controller._clipboardState.lastRead;
+                payload.lastWrite = controller._clipboardState.lastWrite;
+                payload.staleDrops = controller._clipboardState.staleDrops;
+                payload.errorCounts = Object.assign({}, controller._clipboardState.errorCounts || {});
+                payload.permissionDetail = controller._clipboardState.permission;
+                payload.queueState = controller._clipboardState.queueState;
+                if (!payload.state && controller._clipboardBridge && typeof controller._clipboardBridge.getState === "function") {
+                    payload.state = controller._clipboardBridge.getState();
+                }
+                var response = Object.assign({}, basePayload, payload);
+                controller.worker.postMessage(response);
+            }).catch(function(error) {
+                controller._syncClipboardStateFromBridge();
+                controller._clipboardState.queueState = controller._clipboardQueue.getState();
+                var permissionState = controller._clipboardState.permission && controller._clipboardState.permission.write
+                    ? controller._clipboardState.permission.write.state
+                    : "unknown";
+                var formatted = error && error.message ? { name: error.name || "Error", message: error.message } : null;
+                var response = Object.assign({}, basePayload, {
+                    text: text,
+                    fromCache: true,
+                    permission: permissionState,
+                    cachedAt: controller._clipboardState.cachedAt,
+                    lastRead: controller._clipboardState.lastRead,
+                    lastWrite: controller._clipboardState.lastWrite,
+                    staleDrops: controller._clipboardState.staleDrops,
+                    errorCounts: Object.assign({}, controller._clipboardState.errorCounts || {}),
+                    permissionDetail: controller._clipboardState.permission,
+                    queueState: controller._clipboardState.queueState,
+                    state: controller._clipboardBridge && typeof controller._clipboardBridge.getState === "function"
+                        ? controller._clipboardBridge.getState()
+                        : null,
+                });
+                if (formatted) response.error = formatted;
+                controller.worker.postMessage(response);
+            });
         }
     }
 
@@ -367,28 +563,43 @@ export class WorkerVMController {
 
     sendInputEvent(eventPayload) {
         if (!this.worker) throw new Error("Worker VM is not started");
+        this._markGesture();
         this.worker.postMessage({ type: "input-event", event: eventPayload });
     }
 
     sendInputEvents(eventPayloads) {
         if (!this.worker) throw new Error("Worker VM is not started");
         if (!Array.isArray(eventPayloads)) return;
+        this._markGesture();
         this.worker.postMessage({ type: "input-events", events: eventPayloads });
     }
 
     setClipboardText(text, options = {}) {
-        this._clipboardState.text = typeof text === "string" ? text : "";
-        this._clipboardState.lastUpdate = Date.now();
+        var normalized = typeof text === "string" ? text : "";
+        var timestamp = typeof options.timestamp === "number" && isFinite(options.timestamp)
+            ? options.timestamp
+            : Date.now();
+        this._clipboardState.text = normalized;
+        this._clipboardState.cachedAt = timestamp;
+        this._clipboardState.lastWrite = timestamp;
+        if (this._clipboardBridge) {
+            this._clipboardBridge.setCachedText(normalized, timestamp);
+            this._syncClipboardStateFromBridge();
+        }
         if (this.worker) {
             this.worker.postMessage({
                 type: "clipboard-set",
                 text: this._clipboardState.text,
                 changed: options.changed === undefined ? true : !!options.changed,
+                timestamp: timestamp,
             });
         }
     }
 
     requestClipboardText() {
+        if (this._clipboardBridge) {
+            return Promise.resolve(this._clipboardBridge.getCachedText());
+        }
         return Promise.resolve(this._clipboardState.text);
     }
 


### PR DESCRIPTION
## Summary
- add an AudioInputManager that supports microphone, synthetic tone, and file-backed input sessions with registration helpers and diagnostics
- refactor the SoundPlugin recording primitives to route through the new manager and expose a primitive for selecting the active recording source
- document the media input milestone completion and add automated coverage for synthetic and file-backed recording pipelines

## Testing
- node tests/media/audio-input-manager.test.mjs
- node tests/media/audio-output-manager.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e317f0e52c832aa2f0ed295e43a6a1