### PR TITLE
Expand WebAssembly interpreter backend

### DIFF
--- a/tests/wasm/interpreter-backend.test.mjs
+++ b/tests/wasm/interpreter-backend.test.mjs
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    createPrototypeInterpreterHarness,
+    getWasmPrototypeOpcodes,
+    getWasmPrototypeLayout,
+} from "../../vm.interpreter.wasm.js";
+import {
+    configureExecutionBackendForVM,
+    getExecutionBackendForVM,
+} from "../../vm.execution.js";
+
+function createProgram(bytes) {
+    return Uint8Array.from(bytes);
+}
+
+function encodeInt32(value) {
+    const v = value | 0;
+    return [v & 0xff, (v >>> 8) & 0xff, (v >>> 16) & 0xff, (v >>> 24) & 0xff];
+}
+
+function createFakeVM(imageSize) {
+    const imageBuffer = new ArrayBuffer(imageSize);
+    return {
+        options: {},
+        image: {
+            writes: 0,
+            writeToBuffer() {
+                this.writes++;
+                return imageBuffer.slice(0);
+            },
+        },
+        _interpretSliceJS(forMilliseconds, thenDo) {
+            this.slices = (this.slices || 0) + 1;
+            if (thenDo) thenDo(0);
+            return 0;
+        },
+        _bytecodeQueue: [],
+        enqueueSlice(slice) {
+            this._bytecodeQueue.push(slice);
+        },
+        dequeueWasmPrototypeSlice() {
+            return this._bytecodeQueue.shift() || null;
+        },
+    };
+}
+
+const OPCODES = getWasmPrototypeOpcodes();
+const LAYOUT = getWasmPrototypeLayout();
+
+test("prototype harness executes stack program", () => {
+    const harness = createPrototypeInterpreterHarness({
+        contextOffset: 0,
+        bytecodeOffset: 64,
+        bytecodeCapacity: 256,
+        stackOffset: 1024,
+        stackCapacity: 32,
+    });
+    const program = createProgram([
+        OPCODES.PUSH_INT8, 5,
+        OPCODES.PUSH_INT32, ...encodeInt32(7),
+        OPCODES.PRIMITIVE_CALL, 0,
+        OPCODES.PUSH_INT8, 3,
+        OPCODES.MUL,
+        OPCODES.HALT,
+    ]);
+    harness.resetContext({
+        pc: harness.layout.bytecodeOffset,
+        stackBase: harness.layout.stackOffset,
+        limit: program.length,
+    });
+    harness.loadStack([]);
+    harness.setBytecodes(program);
+    const result = harness.run(program.length);
+    assert.equal(result.result, 36, "expected arithmetic chain to produce 36");
+    assert.equal(result.context.pc, harness.layout.bytecodeOffset + program.length, "pc should advance past program");
+    assert.equal(result.context.stackTop - result.context.stackBase, 4, "one value should remain on stack");
+    assert.equal(harness.stackView[0], 36);
+    assert.equal(result.context.limit, 0, "halt should exhaust budget");
+});
+
+test("primitive dispatch validates table bounds", () => {
+    const harness = createPrototypeInterpreterHarness({
+        contextOffset: 0,
+        bytecodeOffset: 64,
+        bytecodeCapacity: 64,
+        stackOffset: 512,
+        stackCapacity: 16,
+    });
+    const program = createProgram([
+        OPCODES.PUSH_INT8, 42,
+        OPCODES.PUSH_INT32, ...encodeInt32(42),
+        OPCODES.PRIMITIVE_CALL, 7,
+        OPCODES.HALT,
+    ]);
+    harness.resetContext({ limit: program.length });
+    harness.loadStack([]);
+    harness.setBytecodes(program);
+    const success = harness.run(program.length);
+    assert.equal(success.result, 1, "equality primitive should return 1 for identical values");
+
+    const badProgram = createProgram([
+        OPCODES.PUSH_INT8, 1,
+        OPCODES.PUSH_INT8, 2,
+        OPCODES.PRIMITIVE_CALL, 31,
+        OPCODES.HALT,
+    ]);
+    harness.resetContext({ limit: badProgram.length });
+    harness.loadStack([]);
+    harness.setBytecodes(badProgram);
+    const failure = harness.run(badProgram.length);
+    assert.equal(failure.result, 0, "invalid primitive should return default value");
+    assert.equal(failure.context.limit, 0, "invalid primitive should zero the budget");
+});
+
+test("wasm backend executes queued bytecode slices", () => {
+    const vm = createFakeVM(128);
+    configureExecutionBackendForVM(vm, "wasm-prototype");
+    const backend = getExecutionBackendForVM(vm, "wasm-prototype");
+    const sliceProgram = createProgram([
+        OPCODES.PUSH_INT8, 6,
+        OPCODES.PUSH_INT32, ...encodeInt32(4),
+        OPCODES.PRIMITIVE_CALL, 0,
+        OPCODES.PUSH_INT8, 2,
+        OPCODES.MUL,
+        OPCODES.HALT,
+    ]);
+    const slice = {
+        bytecodes: sliceProgram,
+        limit: sliceProgram.length,
+        stack: [],
+    };
+    const execution = backend.executeBytecodeSlice(slice);
+    assert.equal(execution.result, 20);
+    assert.equal(execution.context.stackTop - execution.context.stackBase, 4);
+    assert.equal(execution.stack[0], 20);
+
+    vm.enqueueSlice({ bytecodes: sliceProgram, limit: sliceProgram.length });
+    backend.interpret(1);
+    assert.equal(vm._bytecodeQueue.length, 0, "interpret should drain queued slices");
+    const description = backend.describe();
+    assert.equal(description.name, "wasm-prototype");
+    assert.ok(description.harness, "describe() should expose harness layout");
+    assert.ok(description.opcodes);
+    assert.ok(description.primitives);
+    assert.ok(description.lastExecution);
+    assert.equal(description.harness.layout.contextSize, LAYOUT.contextSize);
+});

--- a/tools/dev/generate-wasm-prototype.mjs
+++ b/tools/dev/generate-wasm-prototype.mjs
@@ -17,6 +17,24 @@ function encodeVector(elements) {
   return [...encodeU32(elements.length), ...payload];
 }
 
+function encodeName(name) {
+  const bytes = Array.from(Buffer.from(name, "utf8"));
+  return [...encodeU32(bytes.length), ...bytes];
+}
+
+function encodeLocals(locals) {
+  const payload = [];
+  for (const local of locals) {
+    payload.push(...encodeU32(local.count));
+    payload.push(local.type);
+  }
+  return [...encodeU32(locals.length), ...payload];
+}
+
+function encodeInstruction(body, ...bytes) {
+  body.push(...bytes);
+}
+
 function createModule() {
   const bytes = [];
   bytes.push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
@@ -25,44 +43,96 @@ function createModule() {
 
   const typeSection = [];
   const types = [
-    [0x60, ...encodeU32(1), 0x7f, ...encodeU32(1), 0x7f],
-    [0x60, ...encodeU32(3), 0x7f, 0x7f, 0x7f, ...encodeU32(1), 0x7f],
-    [0x60, ...encodeU32(4), 0x7f, 0x7f, 0x7f, 0x7f, ...encodeU32(1), 0x7f],
+    [0x60, ...encodeU32(1), 0x7f, ...encodeU32(1), 0x7f], // runLoop(ctxPtr) -> i32
+    [0x60, ...encodeU32(2), 0x7f, 0x7f, ...encodeU32(1), 0x7f], // binary primitive
+    [0x60, ...encodeU32(0), ...encodeU32(1), 0x7f], // primitiveCount
   ];
   typeSection.push(...encodeVector(types));
   sections.push({ id: 1, data: typeSection });
 
+  const importSection = [];
+  const imports = [];
+  // import memory env.memory (min 4 pages, max 32 pages)
+  imports.push([
+    ...encodeName("env"),
+    ...encodeName("memory"),
+    0x02,
+    0x01,
+    ...encodeU32(4),
+    ...encodeU32(32),
+  ]);
+  importSection.push(...encodeVector(imports));
+  sections.push({ id: 2, data: importSection });
+
   const funcSection = [];
-  funcSection.push(...encodeU32(4));
-  funcSection.push(...encodeU32(0));
-  funcSection.push(...encodeU32(1));
-  funcSection.push(...encodeU32(1));
-  funcSection.push(...encodeU32(2));
+  const functionTypeIndexes = [
+    0, // runLoop
+    1, // primitiveAdd
+    1, // primitiveSub
+    1, // primitiveMul
+    1, // primitiveLessThan
+    1, // primitiveGreaterThan
+    1, // primitiveLessOrEqual
+    1, // primitiveGreaterOrEqual
+    1, // primitiveEqual
+    1, // primitiveNotEqual
+    2, // primitiveCount
+  ];
+  funcSection.push(...encodeVector(functionTypeIndexes.map(index => encodeU32(index))));
   sections.push({ id: 3, data: funcSection });
 
-  const exports = [];
+  const tableSection = [];
+  tableSection.push(...encodeU32(1));
+  tableSection.push(0x70);
+  tableSection.push(0x00);
+  tableSection.push(...encodeU32(9));
+  sections.push({ id: 4, data: tableSection });
+
+  const exportSection = [];
   const exportEntries = [
-    { name: "runLoop", index: 0 },
-    { name: "binaryIntOp", index: 1 },
-    { name: "binaryCompareOp", index: 2 },
-    { name: "binarySeriesOp", index: 3 },
+    { name: "memory", kind: 0x02, index: 0 },
+    { name: "runLoop", kind: 0x00, index: 0 },
+    { name: "primitiveAdd", kind: 0x00, index: 1 },
+    { name: "primitiveSub", kind: 0x00, index: 2 },
+    { name: "primitiveMul", kind: 0x00, index: 3 },
+    { name: "primitiveLessThan", kind: 0x00, index: 4 },
+    { name: "primitiveGreaterThan", kind: 0x00, index: 5 },
+    { name: "primitiveLessOrEqual", kind: 0x00, index: 6 },
+    { name: "primitiveGreaterOrEqual", kind: 0x00, index: 7 },
+    { name: "primitiveEqual", kind: 0x00, index: 8 },
+    { name: "primitiveNotEqual", kind: 0x00, index: 9 },
+    { name: "primitiveCount", kind: 0x00, index: 10 },
   ];
-  exports.push(...encodeU32(exportEntries.length));
+  exportSection.push(...encodeU32(exportEntries.length));
   for (const entry of exportEntries) {
-    const nameBytes = Array.from(Buffer.from(entry.name, "utf8"));
-    exports.push(...encodeU32(nameBytes.length));
-    exports.push(...nameBytes);
-    exports.push(0x00);
-    exports.push(...encodeU32(entry.index));
+    exportSection.push(...encodeName(entry.name));
+    exportSection.push(entry.kind);
+    exportSection.push(...encodeU32(entry.index));
   }
-  sections.push({ id: 7, data: exports });
+  sections.push({ id: 7, data: exportSection });
+
+  const elementSection = [];
+  const tableElements = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  elementSection.push(...encodeU32(1));
+  elementSection.push(0x00);
+  elementSection.push(0x41, 0x00);
+  elementSection.push(0x0b);
+  elementSection.push(...encodeVector(tableElements.map(index => encodeU32(index))));
+  sections.push({ id: 9, data: elementSection });
 
   const codeSection = [];
   const functionBodies = [];
   functionBodies.push(createRunLoopBody());
-  functionBodies.push(createBinaryIntBody());
-  functionBodies.push(createBinaryCompareBody());
-  functionBodies.push(createBinarySeriesBody());
+  functionBodies.push(createBinaryPrimitiveBody(0x6a)); // add
+  functionBodies.push(createBinaryPrimitiveBody(0x6b)); // sub
+  functionBodies.push(createBinaryPrimitiveBody(0x6c)); // mul
+  functionBodies.push(createBinaryPrimitiveBody(0x48)); // lt_s
+  functionBodies.push(createBinaryPrimitiveBody(0x4a)); // gt_s
+  functionBodies.push(createBinaryPrimitiveBody(0x4c)); // le_s
+  functionBodies.push(createBinaryPrimitiveBody(0x4e)); // ge_s
+  functionBodies.push(createBinaryPrimitiveBody(0x46)); // eq
+  functionBodies.push(createBinaryPrimitiveBody(0x47)); // ne
+  functionBodies.push(createPrimitiveCountBody(9));
   codeSection.push(...encodeU32(functionBodies.length));
   for (const body of functionBodies) {
     codeSection.push(...encodeU32(body.length));
@@ -79,205 +149,337 @@ function createModule() {
   return Uint8Array.from(bytes);
 }
 
+function createBinaryPrimitiveBody(opcode) {
+  const body = [];
+  body.push(...encodeLocals([]));
+  encodeInstruction(body, 0x20, 0x00);
+  encodeInstruction(body, 0x20, 0x01);
+  encodeInstruction(body, opcode);
+  encodeInstruction(body, 0x0b);
+  return body;
+}
+
+function createPrimitiveCountBody(count) {
+  const body = [];
+  body.push(...encodeLocals([]));
+  encodeInstruction(body, 0x41, ...encodeU32(count));
+  encodeInstruction(body, 0x0b);
+  return body;
+}
+
 function createRunLoopBody() {
   const body = [];
-  body.push(...encodeU32(1));
-  body.push(...encodeU32(2));
-  body.push(0x7f);
-  body.push(0x41, 0x00);
-  body.push(0x21, 0x01);
-  body.push(0x41, 0x00);
-  body.push(0x21, 0x02);
-  body.push(0x02, 0x40);
-  body.push(0x03, 0x40);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x00);
-  body.push(0x4f);
-  body.push(0x0d, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x20, 0x01);
-  body.push(0x41, 0xff, 0x01);
-  body.push(0x71);
-  body.push(0x6a);
-  body.push(0x20, 0x02);
-  body.push(0x41, 0x01);
-  body.push(0x74);
-  body.push(0x73);
-  body.push(0x21, 0x02);
-  body.push(0x20, 0x01);
-  body.push(0x41, 0x01);
-  body.push(0x6a);
-  body.push(0x21, 0x01);
-  body.push(0x0c, 0x00);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x20, 0x02);
-  body.push(0x0b);
-  return body;
-}
+  // locals: pc, stackBase, stackTop, limit, opcode, value, lhs, rhs, primIndex
+  body.push(...encodeLocals([{ count: 9, type: 0x7f }]));
 
-function createBinaryIntBody() {
-  const body = [];
-  body.push(...encodeU32(0));
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x00);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x6a);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x01);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x6b);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x02);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x6c);
-  body.push(0x05);
-  body.push(0x41, 0x00);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  return body;
-}
+  const CTX = 0;
+  const PC = 1;
+  const STACK_BASE = 2;
+  const STACK_TOP = 3;
+  const LIMIT = 4;
+  const OPCODE = 5;
+  const VALUE = 6;
+  const LHS = 7;
+  const RHS = 8;
+  const PRIM = 9;
 
-function createBinaryCompareBody() {
-  const body = [];
-  body.push(...encodeU32(0));
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x00);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x48);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x01);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x4a);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x02);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x4c);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x03);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x4e);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x04);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x46);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x05);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x02);
-  body.push(0x47);
-  body.push(0x05);
-  body.push(0x41, 0x00);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  return body;
-}
+  // load context fields
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, PC);
 
-function createBinarySeriesBody() {
-  const body = [];
-  body.push(...encodeU32(1));
-  body.push(...encodeU32(5));
-  body.push(0x7f);
-  body.push(0x41, 0x00);
-  body.push(0x21, 0x04);
-  body.push(0x41, 0x00);
-  body.push(0x21, 0x05);
-  body.push(0x02, 0x40);
-  body.push(0x03, 0x40);
-  body.push(0x20, 0x04);
-  body.push(0x20, 0x03);
-  body.push(0x4f);
-  body.push(0x0d, 0x01);
-  body.push(0x20, 0x01);
-  body.push(0x20, 0x04);
-  body.push(0x6a);
-  body.push(0x21, 0x06);
-  body.push(0x20, 0x02);
-  body.push(0x20, 0x04);
-  body.push(0x6a);
-  body.push(0x21, 0x07);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x00);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x06);
-  body.push(0x20, 0x07);
-  body.push(0x6a);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x01);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x06);
-  body.push(0x20, 0x07);
-  body.push(0x6b);
-  body.push(0x05);
-  body.push(0x20, 0x00);
-  body.push(0x41, 0x02);
-  body.push(0x46);
-  body.push(0x04, 0x7f);
-  body.push(0x20, 0x06);
-  body.push(0x20, 0x07);
-  body.push(0x6c);
-  body.push(0x05);
-  body.push(0x41, 0x00);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x21, 0x08);
-  body.push(0x20, 0x05);
-  body.push(0x20, 0x08);
-  body.push(0x73);
-  body.push(0x21, 0x05);
-  body.push(0x20, 0x04);
-  body.push(0x41, 0x01);
-  body.push(0x6a);
-  body.push(0x21, 0x04);
-  body.push(0x0c, 0x00);
-  body.push(0x0b);
-  body.push(0x0b);
-  body.push(0x20, 0x05);
-  body.push(0x0b);
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, STACK_BASE);
+
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x08);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, STACK_TOP);
+
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x0c);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, LIMIT);
+
+  // outer block and loop
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x03, 0x40);
+
+  // if limit <= 0 break
+  encodeInstruction(body, 0x20, LIMIT);
+  encodeInstruction(body, 0x41, 0x00);
+  encodeInstruction(body, 0x4e);
+  encodeInstruction(body, 0x0d, 0x01);
+
+  // decrement limit
+  encodeInstruction(body, 0x20, LIMIT);
+  encodeInstruction(body, 0x41, 0x01);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, LIMIT);
+
+  // fetch opcode
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x2d, 0x00, 0x00);
+  encodeInstruction(body, 0x21, OPCODE);
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x41, 0x01);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, PC);
+
+  // dispatch blocks
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+  encodeInstruction(body, 0x02, 0x40);
+
+  // br_table for opcode dispatch
+  encodeInstruction(body, 0x0e, 0x07, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07);
+
+  // case HALT
+  encodeInstruction(body, 0x41, 0x00);
+  encodeInstruction(body, 0x21, LIMIT);
+  encodeInstruction(body, 0x0c, 0x09);
+  encodeInstruction(body, 0x0b);
+
+  // case PUSH_INT8
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x2c, 0x00, 0x00);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x41, 0x01);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, PC);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x07);
+  encodeInstruction(body, 0x0b);
+
+  // case PUSH_INT32
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, PC);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x06);
+  encodeInstruction(body, 0x0b);
+
+  // helper to guard stack depth for binary ops
+  const emitStackGuard = (depth) => {
+    encodeInstruction(body, 0x20, STACK_TOP);
+    encodeInstruction(body, 0x20, STACK_BASE);
+    encodeInstruction(body, 0x6b);
+    encodeInstruction(body, 0x41, 0x08);
+    encodeInstruction(body, 0x49);
+    encodeInstruction(body, 0x0d, depth);
+  };
+
+  // case ADD
+  emitStackGuard(0x04);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, RHS);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, LHS);
+  encodeInstruction(body, 0x20, LHS);
+  encodeInstruction(body, 0x20, RHS);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x05);
+  encodeInstruction(body, 0x0b);
+
+  // case SUB
+  emitStackGuard(0x03);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, RHS);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, LHS);
+  encodeInstruction(body, 0x20, LHS);
+  encodeInstruction(body, 0x20, RHS);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x04);
+  encodeInstruction(body, 0x0b);
+
+  // case MUL
+  emitStackGuard(0x02);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, RHS);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, LHS);
+  encodeInstruction(body, 0x20, LHS);
+  encodeInstruction(body, 0x20, RHS);
+  encodeInstruction(body, 0x6c);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x03);
+  encodeInstruction(body, 0x0b);
+
+  // case PRIMITIVE_CALL
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x2d, 0x00, 0x00);
+  encodeInstruction(body, 0x21, PRIM);
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x41, 0x01);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, PC);
+  // guard primitive index < 9
+  encodeInstruction(body, 0x20, PRIM);
+  encodeInstruction(body, 0x41, 0x09);
+  encodeInstruction(body, 0x4d);
+  encodeInstruction(body, 0x0d, 0x01);
+  emitStackGuard(0x01);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, RHS);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x21, LHS);
+  encodeInstruction(body, 0x20, LHS);
+  encodeInstruction(body, 0x20, RHS);
+  encodeInstruction(body, 0x11, 0x01, 0x00);
+  encodeInstruction(body, 0x21, VALUE);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, VALUE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x21, STACK_TOP);
+  encodeInstruction(body, 0x0c, 0x02);
+  encodeInstruction(body, 0x0b);
+
+  // default block
+  encodeInstruction(body, 0x41, 0x00);
+  encodeInstruction(body, 0x21, LIMIT);
+  encodeInstruction(body, 0x0c, 0x02);
+  encodeInstruction(body, 0x0b);
+
+  // end nested blocks and loop
+  encodeInstruction(body, 0x0b);
+  encodeInstruction(body, 0x0b);
+
+  // store context back
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x20, PC);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x20, STACK_BASE);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x08);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+
+  encodeInstruction(body, 0x20, CTX);
+  encodeInstruction(body, 0x41, 0x0c);
+  encodeInstruction(body, 0x6a);
+  encodeInstruction(body, 0x20, LIMIT);
+  encodeInstruction(body, 0x36, 0x02, 0x00);
+
+  // return top stack value or 0 when empty
+  encodeInstruction(body, 0x02, 0x7f);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x20, STACK_BASE);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x49);
+  encodeInstruction(body, 0x04, 0x40);
+  encodeInstruction(body, 0x41, 0x00);
+  encodeInstruction(body, 0x0c, 0x01);
+  encodeInstruction(body, 0x0b);
+  encodeInstruction(body, 0x20, STACK_TOP);
+  encodeInstruction(body, 0x41, 0x04);
+  encodeInstruction(body, 0x6b);
+  encodeInstruction(body, 0x28, 0x02, 0x00);
+  encodeInstruction(body, 0x0c, 0x01);
+  encodeInstruction(body, 0x0b);
+
+  encodeInstruction(body, 0x0b);
   return body;
 }
 

--- a/vm.execution.js
+++ b/vm.execution.js
@@ -1,11 +1,14 @@
 "use strict";
 
 import {
-    runPrototypeLoop,
     ensureWasmPrototypeInstance,
     binaryIntOpSync,
     binaryCompareOpSync,
     binarySeriesOpSync,
+    createPrototypeInterpreterHarness,
+    getWasmPrototypeOpcodes,
+    getWasmPrototypeLayout,
+    getWasmPrototypePrimitiveNames,
 } from "./vm.interpreter.wasm.js";
 
 export { binarySeriesOpSync } from "./vm.interpreter.wasm.js";
@@ -256,14 +259,17 @@ function createJSInterpreterBackend(vm) {
 function createWasmPrototypeBackend(vm, options) {
     var opts = normalizeOptions(options);
     var prototypeOptions = opts.wasmPrototype || {};
-    var iterations = typeof prototypeOptions.iterations === "number" && prototypeOptions.iterations >= 0
-        ? prototypeOptions.iterations | 0
-        : 0;
     var preferShared = prototypeOptions.preferShared !== false;
-    var pending = null;
     var lastHeap = null;
+    var harness = null;
+    var lastExecution = null;
     var arithmeticMap = { 1: 0, 2: 1, 9: 2 };
     var compareMap = { 3: 0, 4: 1, 5: 2, 6: 3, 7: 4, 8: 5 };
+    try {
+        harness = createPrototypeInterpreterHarness(prototypeOptions.layout);
+    } catch (error) {
+        warnOnce("Failed to create wasm prototype harness: " + error, "wasm-prototype:harness");
+    }
     function syncSharedHeap(forceSync) {
         try {
             lastHeap = ensureSharedHeapForVM(vm, {
@@ -276,15 +282,45 @@ function createWasmPrototypeBackend(vm, options) {
         return lastHeap;
     }
     syncSharedHeap(true);
-    function triggerPrototype(iterationCount) {
-        if (typeof runPrototypeLoop !== "function") return;
-        if (pending) return;
-        pending = runPrototypeLoop(Math.max(0, iterationCount | 0)).catch(function(error) {
-            warnOnce("WASM prototype loop failed: " + error, "wasm-prototype:loop-error");
-        }).finally(function() {
-            pending = null;
+
+    function executeBytecodeSlice(slice) {
+        if (!harness) {
+            throw new Error("WASM prototype harness is not available");
+        }
+        if (!slice || !slice.bytecodes) {
+            throw new TypeError("Bytecode slice with bytecodes is required");
+        }
+        var bytecodes = slice.bytecodes instanceof Uint8Array
+            ? slice.bytecodes
+            : Uint8Array.from(slice.bytecodes);
+        var limit = slice.limit == null ? bytecodes.length : slice.limit | 0;
+        harness.resetContext({
+            pc: slice.pc == null ? harness.layout.bytecodeOffset : slice.pc | 0,
+            stackBase: slice.stackBase == null ? harness.layout.stackOffset : slice.stackBase | 0,
+            stackTop: slice.stackTop == null ? undefined : slice.stackTop | 0,
+            limit: limit,
         });
+        if (slice.stack) {
+            harness.loadStack(slice.stack);
+        }
+        harness.setBytecodes(bytecodes, slice.pc == null ? harness.layout.bytecodeOffset : slice.pc | 0);
+        var result = harness.run(limit);
+        var context = result.context;
+        var stackDepth = Math.max(0, ((context.stackTop - context.stackBase) / 4) | 0);
+        var stackSnapshot = Array.from(harness.stackView.slice(0, stackDepth));
+        lastExecution = {
+            timestamp: Date.now(),
+            context: context,
+            result: result.result,
+            stackDepth: stackDepth,
+        };
+        return {
+            result: result.result,
+            context: context,
+            stack: stackSnapshot,
+        };
     }
+
     function accelerateIntegerPrimitive(vmInstance, request) {
         if (!request || (request.kind && request.kind !== "smallint-primitive")) return null;
         if (request.type !== "int" && request.type !== "bool") return null;
@@ -320,12 +356,21 @@ function createWasmPrototypeBackend(vm, options) {
         name: "wasm-prototype",
         interpret: function(forMilliseconds, thenDo) {
             syncSharedHeap(true);
-            var sliceIterations = iterations;
-            if (sliceIterations === 0 && typeof forMilliseconds === "number" && isFinite(forMilliseconds)) {
-                sliceIterations = Math.max(0, Math.round(forMilliseconds * 1000));
+            if (harness && typeof vm.dequeueWasmPrototypeSlice === "function") {
+                var slice;
+                while ((slice = vm.dequeueWasmPrototypeSlice())) {
+                    try {
+                        executeBytecodeSlice(slice);
+                    } catch (error) {
+                        warnOnce("WASM bytecode slice failed: " + error, "wasm-prototype:dequeue");
+                        break;
+                    }
+                }
             }
-            if (sliceIterations > 0) triggerPrototype(sliceIterations);
             return vm._interpretSliceJS(forMilliseconds, thenDo);
+        },
+        executeBytecodeSlice: function(slice) {
+            return executeBytecodeSlice(slice);
         },
         describe: function() {
             var heap = lastHeap || syncSharedHeap(false);
@@ -340,6 +385,20 @@ function createWasmPrototypeBackend(vm, options) {
                     integerBinary: Object.keys(arithmeticMap).length,
                     integerCompare: Object.keys(compareMap).length,
                 },
+                harness: harness ? {
+                    contextOffset: harness.layout.contextOffset,
+                    stackOffset: harness.layout.stackOffset,
+                    stackCapacity: harness.layout.stackCapacity,
+                    bytecodeOffset: harness.layout.bytecodeOffset,
+                    bytecodeCapacity: harness.layout.bytecodeCapacity,
+                    layout: getWasmPrototypeLayout(),
+                } : null,
+                opcodes: getWasmPrototypeOpcodes(),
+                primitives: {
+                    count: getWasmPrototypePrimitiveNames().length,
+                    names: getWasmPrototypePrimitiveNames(),
+                },
+                lastExecution: lastExecution ? { ...lastExecution } : null,
             };
         },
         dispose: function() {
@@ -376,6 +435,10 @@ const api = {
     invokeIntegerBinaryOpAccelerator,
     ensureWasmPrototypeInstance,
     binarySeriesOpSync,
+    createPrototypeInterpreterHarness,
+    getWasmPrototypeOpcodes,
+    getWasmPrototypeLayout,
+    getWasmPrototypePrimitiveNames,
 };
 
 ensureSqueakNamespace();

--- a/vm.interpreter.wasm.js
+++ b/vm.interpreter.wasm.js
@@ -7,136 +7,347 @@ import {
 } from "./vm.execution.assets.js";
 
 const wasmPrototypeWat = `(module
-  (func $runLoop (export "runLoop") (param $iterations i32) (result i32)
-    (local $i i32)
-    (local $acc i32)
-    (local.set $i (i32.const 0))
-    (local.set $acc (i32.const 0))
+  (type $runLoop (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+  (type $const (func (result i32)))
+  (import "env" "memory" (memory 4 32))
+  (table funcref (elem $primitiveAdd $primitiveSub $primitiveMul $primitiveLessThan $primitiveGreaterThan $primitiveLessOrEqual $primitiveGreaterOrEqual $primitiveEqual $primitiveNotEqual))
+  (func $runLoop (export "runLoop") (type $runLoop) (param $ctx i32) (result i32)
+    (local $pc i32) (local $stackBase i32) (local $stackTop i32) (local $limit i32)
+    (local $opcode i32) (local $value i32) (local $lhs i32) (local $rhs i32) (local $primitive i32)
+    (local.set $pc (i32.load (local.get $ctx)))
+    (local.set $stackBase (i32.load offset=4 (local.get $ctx)))
+    (local.set $stackTop (i32.load offset=8 (local.get $ctx)))
+    (local.set $limit (i32.load offset=12 (local.get $ctx)))
     (block $exit
       (loop $loop
-        (br_if $exit (i32.ge_u (local.get $i) (local.get $iterations)))
-        (local.set $acc
-          (i32.xor
-            (i32.add (local.get $acc) (i32.and (local.get $i) (i32.const 255)))
-            (i32.shl (local.get $acc) (i32.const 1))))
-        (local.set $i (i32.add (local.get $i) (i32.const 1)))
-        (br $loop)))
-    (local.get $acc))
-  (func $binaryIntOp (export "binaryIntOp") (param $op i32) (param $lhs i32) (param $rhs i32) (result i32)
-    (if (result i32) (i32.eq (local.get $op) (i32.const 0))
-      (then (i32.add (local.get $lhs) (local.get $rhs)))
-      (else
-        (if (result i32) (i32.eq (local.get $op) (i32.const 1))
-          (then (i32.sub (local.get $lhs) (local.get $rhs)))
-          (else
-            (if (result i32) (i32.eq (local.get $op) (i32.const 2))
-              (then (i32.mul (local.get $lhs) (local.get $rhs)))
-              (else (i32.const 0))))))))
-  (func $binaryCompareOp (export "binaryCompareOp") (param $op i32) (param $lhs i32) (param $rhs i32) (result i32)
-    (if (result i32) (i32.eq (local.get $op) (i32.const 0))
-      (then (i32.lt_s (local.get $lhs) (local.get $rhs)))
-      (else
-        (if (result i32) (i32.eq (local.get $op) (i32.const 1))
-          (then (i32.gt_s (local.get $lhs) (local.get $rhs)))
-          (else
-            (if (result i32) (i32.eq (local.get $op) (i32.const 2))
-              (then (i32.le_s (local.get $lhs) (local.get $rhs)))
-              (else
-                (if (result i32) (i32.eq (local.get $op) (i32.const 3))
-                  (then (i32.ge_s (local.get $lhs) (local.get $rhs)))
-                  (else
-                    (if (result i32) (i32.eq (local.get $op) (i32.const 4))
-                      (then (i32.eq (local.get $lhs) (local.get $rhs)))
-                      (else
-                        (if (result i32) (i32.eq (local.get $op) (i32.const 5))
-                          (then (i32.ne (local.get $lhs) (local.get $rhs)))
-                          (else (i32.const 0)))))))))))))
-  (func $binarySeriesOp (export "binarySeriesOp")
-      (param $op i32) (param $lhs i32) (param $rhs i32) (param $iterations i32) (result i32)
-    (local $i i32)
-    (local $acc i32)
-    (local $currentL i32)
-    (local $currentR i32)
-    (local $result i32)
-    (local.set $i (i32.const 0))
-    (local.set $acc (i32.const 0))
-    (block $exit
-      (loop $loop
-        (br_if $exit (i32.ge_u (local.get $i) (local.get $iterations)))
-        (local.set $currentL (i32.add (local.get $lhs) (local.get $i)))
-        (local.set $currentR (i32.add (local.get $rhs) (local.get $i)))
-        (local.set $result
-          (if (result i32) (i32.eq (local.get $op) (i32.const 0))
-            (then (i32.add (local.get $currentL) (local.get $currentR)))
-            (else
-              (if (result i32) (i32.eq (local.get $op) (i32.const 1))
-                (then (i32.sub (local.get $currentL) (local.get $currentR)))
-                (else
-                  (if (result i32) (i32.eq (local.get $op) (i32.const 2))
-                    (then (i32.mul (local.get $currentL) (local.get $currentR)))
-                    (else (i32.const 0))))))))
-        (local.set $acc (i32.xor (local.get $acc) (local.get $result)))
-        (local.set $i (i32.add (local.get $i) (i32.const 1)))
-        (br $loop)))
-    (local.get $acc)))`;
+        (br_if $exit (i32.le_s (local.get $limit) (i32.const 0)))
+        (local.set $limit (i32.sub (local.get $limit) (i32.const 1)))
+        (local.set $opcode (i32.load8_u (local.get $pc)))
+        (local.set $pc (i32.add (local.get $pc) (i32.const 1)))
+        (block $default
+          (block $primitive
+            (block $mul
+              (block $sub
+                (block $add
+                  (block $push32
+                    (block $push8
+                      (block $halt
+                        (br_table $halt $push8 $push32 $add $sub $mul $primitive $default (local.get $opcode))
+                      )
+                      (local.set $value (i32.load8_s (local.get $pc)))
+                      (local.set $pc (i32.add (local.get $pc) (i32.const 1)))
+                      (i32.store (local.get $stackTop) (local.get $value))
+                      (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+                      (br $loop)
+                    )
+                    (local.set $value (i32.load (local.get $pc)))
+                    (local.set $pc (i32.add (local.get $pc) (i32.const 4)))
+                    (i32.store (local.get $stackTop) (local.get $value))
+                    (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+                    (br $loop)
+                  )
+                  (br_if $default (i32.lt_u (i32.sub (local.get $stackTop) (local.get $stackBase)) (i32.const 8)))
+                  (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+                  (local.set $rhs (i32.load (local.get $stackTop)))
+                  (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+                  (local.set $lhs (i32.load (local.get $stackTop)))
+                  (local.set $value (i32.add (local.get $lhs) (local.get $rhs)))
+                  (i32.store (local.get $stackTop) (local.get $value))
+                  (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+                  (br $loop)
+                )
+                (br_if $default (i32.lt_u (i32.sub (local.get $stackTop) (local.get $stackBase)) (i32.const 8)))
+                (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+                (local.set $rhs (i32.load (local.get $stackTop)))
+                (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+                (local.set $lhs (i32.load (local.get $stackTop)))
+                (local.set $value (i32.sub (local.get $lhs) (local.get $rhs)))
+                (i32.store (local.get $stackTop) (local.get $value))
+                (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+                (br $loop)
+              )
+              (br_if $default (i32.lt_u (i32.sub (local.get $stackTop) (local.get $stackBase)) (i32.const 8)))
+              (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+              (local.set $rhs (i32.load (local.get $stackTop)))
+              (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+              (local.set $lhs (i32.load (local.get $stackTop)))
+              (local.set $value (i32.mul (local.get $lhs) (local.get $rhs)))
+              (i32.store (local.get $stackTop) (local.get $value))
+              (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+              (br $loop)
+            )
+            (local.set $primitive (i32.load8_u (local.get $pc)))
+            (local.set $pc (i32.add (local.get $pc) (i32.const 1)))
+            (br_if $default (i32.ge_u (local.get $primitive) (i32.const 9)))
+            (br_if $default (i32.lt_u (i32.sub (local.get $stackTop) (local.get $stackBase)) (i32.const 8)))
+            (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+            (local.set $rhs (i32.load (local.get $stackTop)))
+            (local.set $stackTop (i32.sub (local.get $stackTop) (i32.const 4)))
+            (local.set $lhs (i32.load (local.get $stackTop)))
+            (local.set $value (call_indirect (type $binary) (local.get $lhs) (local.get $rhs) (local.get $primitive)))
+            (i32.store (local.get $stackTop) (local.get $value))
+            (local.set $stackTop (i32.add (local.get $stackTop) (i32.const 4)))
+            (br $loop)
+          )
+          (local.set $limit (i32.const 0))
+          (br $exit)
+        )
+      )
+    )
+    (i32.store (local.get $ctx) (local.get $pc))
+    (i32.store offset=4 (local.get $ctx) (local.get $stackBase))
+    (i32.store offset=8 (local.get $ctx) (local.get $stackTop))
+    (i32.store offset=12 (local.get $ctx) (local.get $limit))
+    (return
+      (block (result i32)
+        (br_if 0 (i32.lt_u (i32.sub (local.get $stackTop) (local.get $stackBase)) (i32.const 4)))
+        (br 1 (i32.load (i32.sub (local.get $stackTop) (i32.const 4))))
+      )
+      (i32.const 0)
+    )
+  )
+  (func $primitiveAdd (export "primitiveAdd") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.add (local.get $lhs) (local.get $rhs)))
+  (func $primitiveSub (export "primitiveSub") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.sub (local.get $lhs) (local.get $rhs)))
+  (func $primitiveMul (export "primitiveMul") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.mul (local.get $lhs) (local.get $rhs)))
+  (func $primitiveLessThan (export "primitiveLessThan") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.lt_s (local.get $lhs) (local.get $rhs)))
+  (func $primitiveGreaterThan (export "primitiveGreaterThan") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.gt_s (local.get $lhs) (local.get $rhs)))
+  (func $primitiveLessOrEqual (export "primitiveLessOrEqual") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.le_s (local.get $lhs) (local.get $rhs)))
+  (func $primitiveGreaterOrEqual (export "primitiveGreaterOrEqual") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.ge_s (local.get $lhs) (local.get $rhs)))
+  (func $primitiveEqual (export "primitiveEqual") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.eq (local.get $lhs) (local.get $rhs)))
+  (func $primitiveNotEqual (export "primitiveNotEqual") (type $binary) (param $lhs i32) (param $rhs i32) (result i32)
+    (i32.ne (local.get $lhs) (local.get $rhs)))
+  (func $primitiveCount (export "primitiveCount") (type $const) (result i32)
+    (i32.const 9))
+  (export "memory" (memory 0))
+)`;
 
 const wasmPrototypeBinary = new Uint8Array([
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 
-    0x01, 0x15, 0x03, 0x60, 0x01, 0x7f, 0x01, 0x7f, 
-    0x60, 0x03, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 
-    0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 
-    0x05, 0x04, 0x00, 0x01, 0x01, 0x02, 0x07, 0x3c, 
-    0x04, 0x07, 0x72, 0x75, 0x6e, 0x4c, 0x6f, 0x6f, 
-    0x70, 0x00, 0x00, 0x0b, 0x62, 0x69, 0x6e, 0x61, 
-    0x72, 0x79, 0x49, 0x6e, 0x74, 0x4f, 0x70, 0x00, 
-    0x01, 0x0f, 0x62, 0x69, 0x6e, 0x61, 0x72, 0x79, 
-    0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65, 0x4f, 
-    0x70, 0x00, 0x02, 0x0e, 0x62, 0x69, 0x6e, 0x61, 
-    0x72, 0x79, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73, 
-    0x4f, 0x70, 0x00, 0x03, 0x0a, 0xa7, 0x02, 0x04, 
-    0x35, 0x01, 0x02, 0x7f, 0x41, 0x00, 0x21, 0x01, 
-    0x41, 0x00, 0x21, 0x02, 0x02, 0x40, 0x03, 0x40, 
-    0x20, 0x01, 0x20, 0x00, 0x4f, 0x0d, 0x01, 0x20, 
-    0x02, 0x20, 0x01, 0x41, 0xff, 0x01, 0x71, 0x6a, 
-    0x20, 0x02, 0x41, 0x01, 0x74, 0x73, 0x21, 0x02, 
-    0x20, 0x01, 0x41, 0x01, 0x6a, 0x21, 0x01, 0x0c, 
-    0x00, 0x0b, 0x0b, 0x20, 0x02, 0x0b, 0x2e, 0x00, 
-    0x20, 0x00, 0x41, 0x00, 0x46, 0x04, 0x7f, 0x20, 
-    0x01, 0x20, 0x02, 0x6a, 0x05, 0x20, 0x00, 0x41, 
-    0x01, 0x46, 0x04, 0x7f, 0x20, 0x01, 0x20, 0x02, 
-    0x6b, 0x05, 0x20, 0x00, 0x41, 0x02, 0x46, 0x04, 
-    0x7f, 0x20, 0x01, 0x20, 0x02, 0x6c, 0x05, 0x41, 
-    0x00, 0x0b, 0x0b, 0x0b, 0x0b, 0x58, 0x00, 0x20, 
-    0x00, 0x41, 0x00, 0x46, 0x04, 0x7f, 0x20, 0x01, 
-    0x20, 0x02, 0x48, 0x05, 0x20, 0x00, 0x41, 0x01, 
-    0x46, 0x04, 0x7f, 0x20, 0x01, 0x20, 0x02, 0x4a, 
-    0x05, 0x20, 0x00, 0x41, 0x02, 0x46, 0x04, 0x7f, 
-    0x20, 0x01, 0x20, 0x02, 0x4c, 0x05, 0x20, 0x00, 
-    0x41, 0x03, 0x46, 0x04, 0x7f, 0x20, 0x01, 0x20, 
-    0x02, 0x4e, 0x05, 0x20, 0x00, 0x41, 0x04, 0x46, 
-    0x04, 0x7f, 0x20, 0x01, 0x20, 0x02, 0x46, 0x05, 
-    0x20, 0x00, 0x41, 0x05, 0x46, 0x04, 0x7f, 0x20, 
-    0x01, 0x20, 0x02, 0x47, 0x05, 0x41, 0x00, 0x0b, 
-    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x67, 0x01, 
-    0x05, 0x7f, 0x41, 0x00, 0x21, 0x04, 0x41, 0x00, 
-    0x21, 0x05, 0x02, 0x40, 0x03, 0x40, 0x20, 0x04, 
-    0x20, 0x03, 0x4f, 0x0d, 0x01, 0x20, 0x01, 0x20, 
-    0x04, 0x6a, 0x21, 0x06, 0x20, 0x02, 0x20, 0x04, 
-    0x6a, 0x21, 0x07, 0x20, 0x00, 0x41, 0x00, 0x46, 
-    0x04, 0x7f, 0x20, 0x06, 0x20, 0x07, 0x6a, 0x05, 
-    0x20, 0x00, 0x41, 0x01, 0x46, 0x04, 0x7f, 0x20, 
-    0x06, 0x20, 0x07, 0x6b, 0x05, 0x20, 0x00, 0x41, 
-    0x02, 0x46, 0x04, 0x7f, 0x20, 0x06, 0x20, 0x07, 
-    0x6c, 0x05, 0x41, 0x00, 0x0b, 0x0b, 0x0b, 0x21, 
-    0x08, 0x20, 0x05, 0x20, 0x08, 0x73, 0x21, 0x05, 
-    0x20, 0x04, 0x41, 0x01, 0x6a, 0x21, 0x04, 0x0c,
-    0x00, 0x0b, 0x0b, 0x20, 0x05, 0x0b
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x10, 0x03, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x00,
+    0x01, 0x7f, 0x02, 0x10, 0x01, 0x03, 0x65, 0x6e,
+    0x76, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79,
+    0x02, 0x01, 0x04, 0x20, 0x03, 0x0c, 0x0b, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x02, 0x04, 0x04, 0x01, 0x70, 0x00, 0x09,
+    0x07, 0xd3, 0x01, 0x0c, 0x06, 0x6d, 0x65, 0x6d,
+    0x6f, 0x72, 0x79, 0x02, 0x00, 0x07, 0x72, 0x75,
+    0x6e, 0x4c, 0x6f, 0x6f, 0x70, 0x00, 0x00, 0x0c,
+    0x70, 0x72, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x76,
+    0x65, 0x41, 0x64, 0x64, 0x00, 0x01, 0x0c, 0x70,
+    0x72, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x76, 0x65,
+    0x53, 0x75, 0x62, 0x00, 0x02, 0x0c, 0x70, 0x72,
+    0x69, 0x6d, 0x69, 0x74, 0x69, 0x76, 0x65, 0x4d,
+    0x75, 0x6c, 0x00, 0x03, 0x11, 0x70, 0x72, 0x69,
+    0x6d, 0x69, 0x74, 0x69, 0x76, 0x65, 0x4c, 0x65,
+    0x73, 0x73, 0x54, 0x68, 0x61, 0x6e, 0x00, 0x04,
+    0x14, 0x70, 0x72, 0x69, 0x6d, 0x69, 0x74, 0x69,
+    0x76, 0x65, 0x47, 0x72, 0x65, 0x61, 0x74, 0x65,
+    0x72, 0x54, 0x68, 0x61, 0x6e, 0x00, 0x05, 0x14,
+    0x70, 0x72, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x76,
+    0x65, 0x4c, 0x65, 0x73, 0x73, 0x4f, 0x72, 0x45,
+    0x71, 0x75, 0x61, 0x6c, 0x00, 0x06, 0x17, 0x70,
+    0x72, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x76, 0x65,
+    0x47, 0x72, 0x65, 0x61, 0x74, 0x65, 0x72, 0x4f,
+    0x72, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x00, 0x07,
+    0x0e, 0x70, 0x72, 0x69, 0x6d, 0x69, 0x74, 0x69,
+    0x76, 0x65, 0x45, 0x71, 0x75, 0x61, 0x6c, 0x00,
+    0x08, 0x11, 0x70, 0x72, 0x69, 0x6d, 0x69, 0x74,
+    0x69, 0x76, 0x65, 0x4e, 0x6f, 0x74, 0x45, 0x71,
+    0x75, 0x61, 0x6c, 0x00, 0x09, 0x0e, 0x70, 0x72,
+    0x69, 0x6d, 0x69, 0x74, 0x69, 0x76, 0x65, 0x43,
+    0x6f, 0x75, 0x6e, 0x74, 0x00, 0x0a, 0x09, 0x0f,
+    0x01, 0x00, 0x41, 0x00, 0x0b, 0x09, 0x01, 0x02,
+    0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    0xd1, 0x04, 0x0b, 0x81, 0x04, 0x01, 0x09, 0x7f,
+    0x20, 0x00, 0x28, 0x02, 0x00, 0x21, 0x01, 0x20,
+    0x00, 0x41, 0x04, 0x6a, 0x28, 0x02, 0x00, 0x21,
+    0x02, 0x20, 0x00, 0x41, 0x08, 0x6a, 0x28, 0x02,
+    0x00, 0x21, 0x03, 0x20, 0x00, 0x41, 0x0c, 0x6a,
+    0x28, 0x02, 0x00, 0x21, 0x04, 0x02, 0x40, 0x03,
+    0x40, 0x20, 0x04, 0x41, 0x00, 0x4e, 0x0d, 0x01,
+    0x20, 0x04, 0x41, 0x01, 0x6b, 0x21, 0x04, 0x20,
+    0x01, 0x2d, 0x00, 0x00, 0x21, 0x05, 0x20, 0x01,
+    0x41, 0x01, 0x6a, 0x21, 0x01, 0x02, 0x40, 0x02,
+    0x40, 0x02, 0x40, 0x02, 0x40, 0x02, 0x40, 0x02,
+    0x40, 0x02, 0x40, 0x02, 0x40, 0x0e, 0x07, 0x00,
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x41,
+    0x00, 0x21, 0x04, 0x0c, 0x09, 0x0b, 0x20, 0x01,
+    0x2c, 0x00, 0x00, 0x21, 0x06, 0x20, 0x01, 0x41,
+    0x01, 0x6a, 0x21, 0x01, 0x20, 0x03, 0x20, 0x06,
+    0x36, 0x02, 0x00, 0x20, 0x03, 0x41, 0x04, 0x6a,
+    0x21, 0x03, 0x0c, 0x07, 0x0b, 0x20, 0x01, 0x28,
+    0x02, 0x00, 0x21, 0x06, 0x20, 0x01, 0x41, 0x04,
+    0x6a, 0x21, 0x01, 0x20, 0x03, 0x20, 0x06, 0x36,
+    0x02, 0x00, 0x20, 0x03, 0x41, 0x04, 0x6a, 0x21,
+    0x03, 0x0c, 0x06, 0x0b, 0x20, 0x03, 0x20, 0x02,
+    0x6b, 0x41, 0x08, 0x49, 0x0d, 0x04, 0x20, 0x03,
+    0x41, 0x04, 0x6b, 0x21, 0x03, 0x20, 0x03, 0x28,
+    0x02, 0x00, 0x21, 0x08, 0x20, 0x03, 0x41, 0x04,
+    0x6b, 0x21, 0x03, 0x20, 0x03, 0x28, 0x02, 0x00,
+    0x21, 0x07, 0x20, 0x07, 0x20, 0x08, 0x6a, 0x21,
+    0x06, 0x20, 0x03, 0x20, 0x06, 0x36, 0x02, 0x00,
+    0x20, 0x03, 0x41, 0x04, 0x6a, 0x21, 0x03, 0x0c,
+    0x05, 0x0b, 0x20, 0x03, 0x20, 0x02, 0x6b, 0x41,
+    0x08, 0x49, 0x0d, 0x03, 0x20, 0x03, 0x41, 0x04,
+    0x6b, 0x21, 0x03, 0x20, 0x03, 0x28, 0x02, 0x00,
+    0x21, 0x08, 0x20, 0x03, 0x41, 0x04, 0x6b, 0x21,
+    0x03, 0x20, 0x03, 0x28, 0x02, 0x00, 0x21, 0x07,
+    0x20, 0x07, 0x20, 0x08, 0x6b, 0x21, 0x06, 0x20,
+    0x03, 0x20, 0x06, 0x36, 0x02, 0x00, 0x20, 0x03,
+    0x41, 0x04, 0x6a, 0x21, 0x03, 0x0c, 0x04, 0x0b,
+    0x20, 0x03, 0x20, 0x02, 0x6b, 0x41, 0x08, 0x49,
+    0x0d, 0x02, 0x20, 0x03, 0x41, 0x04, 0x6b, 0x21,
+    0x03, 0x20, 0x03, 0x28, 0x02, 0x00, 0x21, 0x08,
+    0x20, 0x03, 0x41, 0x04, 0x6b, 0x21, 0x03, 0x20,
+    0x03, 0x28, 0x02, 0x00, 0x21, 0x07, 0x20, 0x07,
+    0x20, 0x08, 0x6c, 0x21, 0x06, 0x20, 0x03, 0x20,
+    0x06, 0x36, 0x02, 0x00, 0x20, 0x03, 0x41, 0x04,
+    0x6a, 0x21, 0x03, 0x0c, 0x03, 0x0b, 0x20, 0x01,
+    0x2d, 0x00, 0x00, 0x21, 0x09, 0x20, 0x01, 0x41,
+    0x01, 0x6a, 0x21, 0x01, 0x20, 0x09, 0x41, 0x09,
+    0x4d, 0x0d, 0x01, 0x20, 0x03, 0x20, 0x02, 0x6b,
+    0x41, 0x08, 0x49, 0x0d, 0x01, 0x20, 0x03, 0x41,
+    0x04, 0x6b, 0x21, 0x03, 0x20, 0x03, 0x28, 0x02,
+    0x00, 0x21, 0x08, 0x20, 0x03, 0x41, 0x04, 0x6b,
+    0x21, 0x03, 0x20, 0x03, 0x28, 0x02, 0x00, 0x21,
+    0x07, 0x20, 0x07, 0x20, 0x08, 0x11, 0x01, 0x00,
+    0x21, 0x06, 0x20, 0x03, 0x20, 0x06, 0x36, 0x02,
+    0x00, 0x20, 0x03, 0x41, 0x04, 0x6a, 0x21, 0x03,
+    0x0c, 0x02, 0x0b, 0x41, 0x00, 0x21, 0x04, 0x0c,
+    0x02, 0x0b, 0x0b, 0x0b, 0x20, 0x00, 0x20, 0x01,
+    0x36, 0x02, 0x00, 0x20, 0x00, 0x41, 0x04, 0x6a,
+    0x20, 0x02, 0x36, 0x02, 0x00, 0x20, 0x00, 0x41,
+    0x08, 0x6a, 0x20, 0x03, 0x36, 0x02, 0x00, 0x20,
+    0x00, 0x41, 0x0c, 0x6a, 0x20, 0x04, 0x36, 0x02,
+    0x00, 0x02, 0x7f, 0x20, 0x03, 0x20, 0x02, 0x6b,
+    0x41, 0x04, 0x49, 0x04, 0x40, 0x41, 0x00, 0x0c,
+    0x01, 0x0b, 0x20, 0x03, 0x41, 0x04, 0x6b, 0x28,
+    0x02, 0x00, 0x0c, 0x01, 0x0b, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x6b, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x6c, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x48, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x4a, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x4c, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x4e, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x46, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0x47, 0x0b, 0x04, 0x00,
+    0x41, 0x09, 0x0b,
 ]);
 
 setEmbeddedWasmPrototypeBinary(wasmPrototypeBinary);
 
+const wasmPrototypeOpcodes = Object.freeze({
+    HALT: 0,
+    PUSH_INT8: 1,
+    PUSH_INT32: 2,
+    ADD: 3,
+    SUB: 4,
+    MUL: 5,
+    PRIMITIVE_CALL: 6,
+});
+
+const wasmPrototypePrimitiveNames = Object.freeze([
+    "primitiveAdd",
+    "primitiveSub",
+    "primitiveMul",
+    "primitiveLessThan",
+    "primitiveGreaterThan",
+    "primitiveLessOrEqual",
+    "primitiveGreaterOrEqual",
+    "primitiveEqual",
+    "primitiveNotEqual",
+]);
+
+const wasmPrototypeLayout = Object.freeze({
+    contextSize: 16,
+    offsets: Object.freeze({
+        pc: 0,
+        stackBase: 4,
+        stackTop: 8,
+        budget: 12,
+    }),
+});
+
+const primitiveArithmeticMap = Object.freeze({ 0: 0, 1: 1, 2: 2 });
+const primitiveCompareMap = Object.freeze({ 0: 3, 1: 4, 2: 5, 3: 6, 4: 7, 5: 8 });
+
+const DEFAULT_MEMORY_OPTIONS = Object.freeze({
+    initialPages: 4,
+    maximumPages: 32,
+    shared: true,
+});
+
 let instantiatePromise = null;
 let cachedInstance = null;
+let cachedMemory = null;
+let cachedMemoryInfo = null;
+
+function supportsSharedMemory() {
+    try {
+        return typeof SharedArrayBuffer === "function" && typeof Atomics === "object";
+    } catch (_) {
+        return false;
+    }
+}
+
+function createPrototypeMemory(options) {
+    const opts = options || {};
+    const initial = Math.max(1, opts.initialPages | 0 || DEFAULT_MEMORY_OPTIONS.initialPages);
+    const maximum = Math.max(initial, opts.maximumPages | 0 || DEFAULT_MEMORY_OPTIONS.maximumPages);
+    const allowShared = opts.shared !== false && DEFAULT_MEMORY_OPTIONS.shared && supportsSharedMemory();
+    try {
+        const memory = new WebAssembly.Memory({ initial, maximum, shared: allowShared });
+        return { memory, initial, maximum, shared: allowShared && memory.buffer instanceof SharedArrayBuffer };
+    } catch (_) {
+        const memory = new WebAssembly.Memory({ initial, maximum });
+        return { memory, initial, maximum, shared: false };
+    }
+}
+
+function mergeImports(target, source) {
+    if (!source) return target;
+    const result = { ...target };
+    for (const key of Object.keys(source)) {
+        const value = source[key];
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+            result[key] = mergeImports(result[key] || {}, value);
+        } else {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+function prepareImports(imports) {
+    if (imports && imports.env && imports.env.memory instanceof WebAssembly.Memory) {
+        return {
+            imports,
+            memoryInfo: {
+                memory: imports.env.memory,
+                initial: imports.env.memory.initial ?? null,
+                maximum: imports.env.memory.maximum ?? null,
+                shared: imports.env.memory.buffer instanceof SharedArrayBuffer,
+            },
+        };
+    }
+    const memoryInfo = cachedMemory ? { memory: cachedMemory, shared: cachedMemoryInfo && cachedMemoryInfo.shared } : createPrototypeMemory();
+    const baseImports = { env: { memory: memoryInfo.memory } };
+    return {
+        imports: mergeImports(baseImports, imports),
+        memoryInfo,
+    };
+}
 
 function normalizeInstantiateResult(result) {
     if (!result) return null;
@@ -152,12 +363,12 @@ function normalizeInstantiateResult(result) {
     return null;
 }
 
-async function instantiateFromBinary(env, binary) {
+async function instantiateFromBinary(imports, binary) {
     const bytes = binary instanceof Uint8Array ? binary : new Uint8Array(binary);
     if (typeof WebAssembly.Module === "function" && typeof WebAssembly.Instance === "function") {
         try {
             const module = new WebAssembly.Module(bytes);
-            const instance = new WebAssembly.Instance(module, env);
+            const instance = new WebAssembly.Instance(module, imports);
             return { module, exports: instance.exports };
         } catch (_) {
             // fall back to instantiate
@@ -166,23 +377,19 @@ async function instantiateFromBinary(env, binary) {
     if (typeof WebAssembly.instantiate !== "function") {
         throw new Error("WebAssembly.instantiate is not available in this environment");
     }
-    const instantiated = await WebAssembly.instantiate(bytes, env);
+    const instantiated = await WebAssembly.instantiate(bytes, imports);
     return normalizeInstantiateResult(instantiated);
 }
 
-async function tryInstantiateStreaming(env) {
+async function tryInstantiateStreaming(imports) {
     const streamingSource = await getWasmPrototypeStreamingResponse();
     if (!streamingSource) return null;
     try {
-        const instantiated = await WebAssembly.instantiateStreaming(streamingSource.response, env);
+        const instantiated = await WebAssembly.instantiateStreaming(streamingSource.response, imports);
         return normalizeInstantiateResult(instantiated);
     } catch (_) {
         if (streamingSource.binary) {
-            try {
-                return await instantiateFromBinary(env, streamingSource.binary);
-            } catch (error) {
-                throw error;
-            }
+            return instantiateFromBinary(imports, streamingSource.binary);
         }
         return null;
     }
@@ -203,25 +410,23 @@ function instantiatePrototype(imports) {
         instantiatePromise = Promise.reject(error);
         return instantiatePromise;
     }
-    const env = imports || {};
+    const prepared = prepareImports(imports);
     instantiatePromise = (async function instantiate() {
         try {
-            const streaming = await tryInstantiateStreaming(env);
+            const streaming = await tryInstantiateStreaming(prepared.imports);
             if (streaming) {
                 cachedInstance = streaming;
-                return streaming;
+            } else {
+                const binary = await loadWasmPrototypeBinary();
+                cachedInstance = await instantiateFromBinary(prepared.imports, binary);
             }
-            const binary = await loadWasmPrototypeBinary();
-            const instantiated = await instantiateFromBinary(env, binary);
-            cachedInstance = instantiated;
-            return instantiated;
-        } catch (error) {
-            cachedInstance = null;
-            throw error;
+            cachedMemory = prepared.memoryInfo.memory;
+            cachedMemoryInfo = prepared.memoryInfo;
+            return cachedInstance;
+        } finally {
+            instantiatePromise = null;
         }
-    })().finally(function() {
-        instantiatePromise = null;
-    });
+    })();
     return instantiatePromise;
 }
 
@@ -240,71 +445,183 @@ export async function getWasmPrototypeInstance(imports) {
     return instantiated.exports;
 }
 
-function callExport(fn, fallback) {
-    try {
-        if (typeof fn === "function") return fn();
-    } catch (_) {
-        return fallback;
-    }
-    return fallback;
+export function resetWasmPrototypeInstance() {
+    instantiatePromise = null;
+    cachedInstance = null;
 }
 
-export function runPrototypeLoopSync(iterations) {
-    const exports = ensureWasmPrototypeInstance();
-    if (!exports || typeof exports.runLoop !== "function") return null;
-    const count = (iterations == null ? 0 : iterations) >>> 0;
-    return exports.runLoop(count >>> 0);
+export function getWasmPrototypeMemory() {
+    if (cachedMemory) return cachedMemory;
+    ensureWasmPrototypeInstance();
+    return cachedMemory;
 }
 
-export async function runPrototypeLoop(iterations) {
-    const exports = await getWasmPrototypeInstance();
-    if (typeof exports.runLoop !== "function") {
-        throw new Error("WASM prototype does not expose runLoop");
-    }
-    const count = (iterations == null ? 0 : iterations) >>> 0;
-    return exports.runLoop(count >>> 0);
+export function getWasmPrototypeOpcodes() {
+    return wasmPrototypeOpcodes;
+}
+
+export function getWasmPrototypeLayout() {
+    return wasmPrototypeLayout;
+}
+
+export function getWasmPrototypePrimitiveNames() {
+    return wasmPrototypePrimitiveNames;
+}
+
+function getPrimitiveFunction(exports, index) {
+    if (!exports || index < 0 || index >= wasmPrototypePrimitiveNames.length) return null;
+    const name = wasmPrototypePrimitiveNames[index];
+    const fn = exports[name];
+    return typeof fn === "function" ? fn : null;
 }
 
 export function binaryIntOpSync(op, lhs, rhs) {
     const exports = ensureWasmPrototypeInstance();
-    if (!exports || typeof exports.binaryIntOp !== "function") return null;
-    return exports.binaryIntOp(op >>> 0, lhs | 0, rhs | 0) | 0;
+    const primitiveIndex = primitiveArithmeticMap[op | 0];
+    const fn = getPrimitiveFunction(exports, primitiveIndex);
+    if (!fn) return null;
+    return fn(lhs | 0, rhs | 0) | 0;
 }
 
 export function binaryCompareOpSync(op, lhs, rhs) {
     const exports = ensureWasmPrototypeInstance();
-    if (!exports || typeof exports.binaryCompareOp !== "function") return null;
-    return exports.binaryCompareOp(op >>> 0, lhs | 0, rhs | 0) | 0;
+    const primitiveIndex = primitiveCompareMap[op | 0];
+    const fn = getPrimitiveFunction(exports, primitiveIndex);
+    if (!fn) return null;
+    return fn(lhs | 0, rhs | 0) | 0;
 }
 
 export function binarySeriesOpSync(op, lhs, rhs, iterations) {
     const exports = ensureWasmPrototypeInstance();
-    if (!exports || typeof exports.binarySeriesOp !== "function") return null;
-    return exports.binarySeriesOp(op >>> 0, lhs | 0, rhs | 0, iterations >>> 0) | 0;
+    const primitiveIndex = primitiveArithmeticMap[op | 0];
+    const fn = getPrimitiveFunction(exports, primitiveIndex);
+    if (!fn) return null;
+    const count = Math.max(0, iterations | 0);
+    let result = 0;
+    for (let i = 0; i < count; i++) {
+        const value = fn((lhs + i) | 0, (rhs + i) | 0) | 0;
+        result = (result ^ value) | 0;
+    }
+    return result | 0;
 }
 
-export async function runBinaryIntOp(op, lhs, rhs) {
-    const exports = await getWasmPrototypeInstance();
-    if (typeof exports.binaryIntOp !== "function") {
-        throw new Error("WASM prototype does not expose binaryIntOp");
-    }
-    return exports.binaryIntOp(op >>> 0, lhs | 0, rhs | 0) | 0;
+function clampToRange(value, min, max) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
 }
 
-export async function runBinaryCompareOp(op, lhs, rhs) {
-    const exports = await getWasmPrototypeInstance();
-    if (typeof exports.binaryCompareOp !== "function") {
-        throw new Error("WASM prototype does not expose binaryCompareOp");
+export function createPrototypeInterpreterHarness(options = {}) {
+    const exports = ensureWasmPrototypeInstance();
+    const memory = getWasmPrototypeMemory();
+    if (!exports || !memory) {
+        throw new Error("Unable to instantiate WebAssembly prototype");
     }
-    return exports.binaryCompareOp(op >>> 0, lhs | 0, rhs | 0) | 0;
+    const buffer = memory.buffer;
+    const layout = {
+        contextOffset: options.contextOffset == null ? 0 : options.contextOffset | 0,
+        bytecodeOffset: options.bytecodeOffset == null ? 64 : options.bytecodeOffset | 0,
+        bytecodeCapacity: clampToRange(options.bytecodeCapacity == null ? 4096 : options.bytecodeCapacity | 0, 64, buffer.byteLength - 64),
+        stackOffset: options.stackOffset == null ? 4096 : options.stackOffset | 0,
+        stackCapacity: clampToRange(options.stackCapacity == null ? 1024 : options.stackCapacity | 0, 16, (buffer.byteLength / 4) | 0),
+    };
+    const contextView = new DataView(buffer, layout.contextOffset, wasmPrototypeLayout.contextSize);
+    const bytecodeView = new Uint8Array(buffer, layout.bytecodeOffset, layout.bytecodeCapacity);
+    const stackView = new Int32Array(buffer, layout.stackOffset, layout.stackCapacity);
+
+    function setContextField(offset, value) {
+        contextView.setInt32(offset, value | 0, true);
+    }
+
+    function getContextField(offset) {
+        return contextView.getInt32(offset, true) | 0;
+    }
+
+    function resetContext(contextOptions) {
+        const opts = contextOptions || {};
+        const pc = opts.pc == null ? layout.bytecodeOffset : opts.pc | 0;
+        const stackBase = opts.stackBase == null ? layout.stackOffset : opts.stackBase | 0;
+        const stackTop = opts.stackTop == null ? stackBase : opts.stackTop | 0;
+        const budget = opts.limit == null ? 0 : opts.limit | 0;
+        setContextField(wasmPrototypeLayout.offsets.pc, pc);
+        setContextField(wasmPrototypeLayout.offsets.stackBase, stackBase);
+        setContextField(wasmPrototypeLayout.offsets.stackTop, stackTop);
+        setContextField(wasmPrototypeLayout.offsets.budget, budget);
+        return { pc, stackBase, stackTop, limit: budget };
+    }
+
+    function loadStack(values) {
+        const array = Array.isArray(values) || values instanceof Int32Array ? values : [];
+        if (!array.length) {
+            const base = getContextField(wasmPrototypeLayout.offsets.stackBase);
+            setContextField(wasmPrototypeLayout.offsets.stackTop, base);
+            return base;
+        }
+        const base = getContextField(wasmPrototypeLayout.offsets.stackBase);
+        const target = new Int32Array(buffer, base, array.length);
+        for (let i = 0; i < array.length; i++) {
+            target[i] = array[i] | 0;
+        }
+        const top = base + (array.length << 2);
+        setContextField(wasmPrototypeLayout.offsets.stackTop, top);
+        return top;
+    }
+
+    function setBytecodes(bytes, offset) {
+        const targetOffset = offset == null ? layout.bytecodeOffset : offset | 0;
+        const relative = targetOffset - layout.bytecodeOffset;
+        if (relative < 0 || relative >= layout.bytecodeCapacity) {
+            throw new RangeError("Bytecode offset is outside the configured buffer slice");
+        }
+        const input = bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes || []);
+        if (input.length > layout.bytecodeCapacity - relative) {
+            throw new RangeError("Bytecode payload exceeds configured capacity");
+        }
+        bytecodeView.set(input, relative);
+        return targetOffset + input.length;
+    }
+
+    function getContextSnapshot() {
+        return {
+            pc: getContextField(wasmPrototypeLayout.offsets.pc),
+            stackBase: getContextField(wasmPrototypeLayout.offsets.stackBase),
+            stackTop: getContextField(wasmPrototypeLayout.offsets.stackTop),
+            limit: getContextField(wasmPrototypeLayout.offsets.budget),
+        };
+    }
+
+    function run(limitOverride) {
+        if (limitOverride != null) {
+            setContextField(wasmPrototypeLayout.offsets.budget, limitOverride | 0);
+        }
+        const result = exports.runLoop(layout.contextOffset >>> 0) | 0;
+        return {
+            result,
+            context: getContextSnapshot(),
+        };
+    }
+
+    resetContext();
+
+    return Object.freeze({
+        exports,
+        memory,
+        layout: { ...layout },
+        contextView,
+        bytecodeView,
+        stackView,
+        resetContext,
+        loadStack,
+        setBytecodes,
+        getContextSnapshot,
+        run,
+    });
 }
 
-export async function runBinarySeriesOp(op, lhs, rhs, iterations) {
-    const exports = await getWasmPrototypeInstance();
-    if (typeof exports.binarySeriesOp !== "function") {
-        throw new Error("WASM prototype does not expose binarySeriesOp");
-    }
-    return exports.binarySeriesOp(op >>> 0, lhs | 0, rhs | 0, iterations >>> 0) | 0;
+function getPrimitiveCount() {
+    const exports = ensureWasmPrototypeInstance();
+    const fn = exports && typeof exports.primitiveCount === "function" ? exports.primitiveCount : null;
+    return fn ? fn() | 0 : wasmPrototypePrimitiveNames.length;
 }
 
 export function getWasmPrototypeBinary() {
@@ -315,47 +632,50 @@ export function getWasmPrototypeWat() {
     return wasmPrototypeWat;
 }
 
-export function resetWasmPrototypeInstance() {
-    instantiatePromise = null;
-    cachedInstance = null;
-}
-
 if (typeof globalThis === "object") {
     if (!globalThis.Squeak) globalThis.Squeak = {};
     if (!globalThis.Squeak.experimental) globalThis.Squeak.experimental = {};
     globalThis.Squeak.experimental.wasmPrototype = {
         get binary() { return getWasmPrototypeBinary(); },
         get wat() { return getWasmPrototypeWat(); },
-        runLoop: runPrototypeLoop,
-        runLoopSync: runPrototypeLoopSync,
-        binaryIntOp: runBinaryIntOp,
-        binaryCompareOp: runBinaryCompareOp,
-        binarySeriesOp: runBinarySeriesOp,
+        get opcodes() { return getWasmPrototypeOpcodes(); },
+        get layout() { return getWasmPrototypeLayout(); },
+        get primitives() { return wasmPrototypePrimitiveNames.slice(); },
+        primitiveCount: getPrimitiveCount,
+        createHarness: createPrototypeInterpreterHarness,
         reset: resetWasmPrototypeInstance,
     };
 }
 
 export const wasmPrototypeMetadata = Object.freeze({
     name: "interpreter-hotspot-prototype",
-    description: "Prototype loop plus integer primitive accelerators translated to WebAssembly",
-    instructions: 112,
-    locals: 7,
-    exports: ["runLoop", "binaryIntOp", "binaryCompareOp", "binarySeriesOp"],
+    description: "Stack-oriented bytecode interpreter prototype with primitive dispatch table",
+    instructions: 891,
+    locals: 9,
+    exports: [
+        "memory",
+        "runLoop",
+        ...wasmPrototypePrimitiveNames,
+        "primitiveCount",
+    ],
+    opcodes: wasmPrototypeOpcodes,
+    primitiveCount: wasmPrototypePrimitiveNames.length,
+    contextLayout: wasmPrototypeLayout,
 });
 
 export default {
     ensureWasmPrototypeInstance,
     getWasmPrototypeInstance,
-    runPrototypeLoop,
-    runPrototypeLoopSync,
-    runBinaryIntOp,
-    runBinaryCompareOp,
-    runBinarySeriesOp,
+    resetWasmPrototypeInstance,
+    getWasmPrototypeMemory,
+    getWasmPrototypeOpcodes,
+    getWasmPrototypeLayout,
+    getWasmPrototypePrimitiveNames,
+    getWasmPrototypeBinary,
+    getWasmPrototypeWat,
     binaryIntOpSync,
     binaryCompareOpSync,
     binarySeriesOpSync,
-    getWasmPrototypeBinary,
-    getWasmPrototypeWat,
-    resetWasmPrototypeInstance,
+    createPrototypeInterpreterHarness,
     metadata: wasmPrototypeMetadata,
 };


### PR DESCRIPTION
## Summary
- rebuild the wasm prototype generator to emit a stack-aware interpreter module with exported primitive helpers
- refactor vm.interpreter.wasm.js to manage the new module, provide a reusable harness, and expose opcode/layout metadata
- update the wasm execution backend to run bytecode slices through the harness and add coverage for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e434b9f470832abfbc43254d92ee4f