### PR TITLE
Fix storage service worker URL resolution

### DIFF
--- a/vm.storage.vfs.js
+++ b/vm.storage.vfs.js
@@ -3,8 +3,17 @@ import { scheduleStorageReconciliation } from "./vm.storage.reconcile.js";
 
 "use strict";
 
+function resolveDefaultScriptURL() {
+    try {
+        if (typeof import.meta !== "undefined" && import.meta.url) {
+            return new URL("./run/squeak-storage-sw.js", import.meta.url).toString();
+        }
+    } catch (_) {}
+    return "./run/squeak-storage-sw.js";
+}
+
 const DEFAULT_SCOPE = "./";
-const DEFAULT_SCRIPT_URL = "./run/squeak-storage-sw.js";
+const DEFAULT_SCRIPT_URL = resolveDefaultScriptURL();
 const DEFAULT_CACHE_NAME = "squeak-vfs-cache";
 const STORAGE_CHANNEL = "squeak-storage-vfs";
 const VFS_URL_PREFIX = "https://squeak.invalid/vfs/";


### PR DESCRIPTION
## Summary
- resolve the storage VFS service worker URL relative to the module so pages under nested paths load it correctly
- retain the previous relative fallback when module metadata is unavailable

## Testing
- node tests/storage/storage-vfs.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e4487f718c832a94af4894d3ef0be0