### PR TITLE
Handle missing Spur class table entries

### DIFF
--- a/tests/unit/vm.image.class-table.test.js
+++ b/tests/unit/vm.image.class-table.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+if (typeof globalThis.self === "undefined") {
+  globalThis.self = globalThis;
+}
+
+await import("../../globals.js");
+await import("../../vm.js");
+await import("../../vm.object.js");
+await import("../../vm.object.spur.js");
+await import("../../vm.image.js");
+
+test("spurClassTable tolerates missing entries", () => {
+  const image = new Squeak.Image("test.image");
+  image.headerAudit.reset("test.image");
+
+  const nilObject = new Squeak.ObjectSpur();
+  nilObject.oop = 0;
+  image.firstOldObject = nilObject;
+
+  const validClass = new Squeak.ObjectSpur();
+  validClass.oop = 0x2000;
+  validClass.hash = 0x345;
+
+  const classPageObject = new Squeak.ObjectSpur();
+  classPageObject.oop = 0x1000;
+
+  const classPageBits = new Uint32Array(1024);
+  classPageBits[1] = 0x123456; // missing entry
+  classPageBits[2] = validClass.oop;
+
+  const classPages = new Uint32Array(4096);
+  classPages[0] = classPageObject.oop;
+
+  const specialObjects = new Squeak.ObjectSpur();
+  specialObjects.oop = 0x3000;
+
+  const oopMap = new Map();
+  oopMap.set(nilObject.oop, nilObject);
+  oopMap.set(validClass.oop, validClass);
+  oopMap.set(classPageObject.oop, classPageObject);
+  oopMap.set(specialObjects.oop, specialObjects);
+
+  const rawBits = new Map();
+  rawBits.set(classPageObject.oop, classPageBits);
+  rawBits.set(specialObjects.oop, new Uint32Array(64));
+
+  const classes = image.spurClassTable(oopMap, rawBits, classPages, specialObjects);
+
+  assert.strictEqual(classes[2], validClass, "valid class entries should be retained");
+  const issueCodes = image.headerAudit.issues.map((issue) => issue.code);
+  assert.ok(issueCodes.includes("class-table-entry-missing"), "missing class entries should be recorded as issues");
+});

--- a/vm.image.js
+++ b/vm.image.js
@@ -1446,18 +1446,49 @@ Object.subclass('Squeak.Image',
     },
     spurClassTable: function(oopMap, rawBits, classPages, splObjs) {
         var classes = {},
-            nil = this.firstOldObject;
+            nil = this.firstOldObject,
+            audit = this.headerAudit || null;
         // read class table pages
         for (var p = 0; p < 4096; p++) {
-            var page = oopMap.get(classPages[p]);
-            if (page.oop) page = rawBits.get(page.oop); // page was not properly hidden
-            if (page.length === 1024) for (var i = 0; i < 1024; i++) {
-                var entry = oopMap.get(page[i]);
-                if (!entry) throw Error("Invalid class table entry (oop " + page[i] + ")");
-                if (entry !== nil) {
-                    var classIndex = p * 1024 + i;
-                    classes[classIndex] = entry;
+            var pagePointer = classPages[p];
+            if (!pagePointer) continue;
+            var pageObject = oopMap.get(pagePointer);
+            if (!pageObject) {
+                if (audit) {
+                    audit.recordIssue("class-table-page-missing", {
+                        pageIndex: p,
+                        pagePointer: pagePointer >>> 0,
+                    });
                 }
+                continue;
+            }
+            var page = pageObject;
+            if (pageObject.oop && rawBits.has(pageObject.oop)) {
+                var bits = rawBits.get(pageObject.oop);
+                if (bits) page = bits;
+            } else if (Array.isArray(pageObject.pointers)) {
+                page = pageObject.pointers;
+            }
+            if (!page || typeof page.length !== "number") continue;
+            var entryCount = page.length >>> 0;
+            for (var i = 0; i < entryCount; i++) {
+                var entryPointer = page[i];
+                if (!entryPointer) continue;
+                if ((entryPointer & 1) === 1) continue;
+                var entry = oopMap.get(entryPointer);
+                if (!entry) {
+                    if (audit) {
+                        audit.recordIssue("class-table-entry-missing", {
+                            pageIndex: p,
+                            entryIndex: i,
+                            entryPointer: entryPointer >>> 0,
+                        });
+                    }
+                    continue;
+                }
+                if (entry === nil) continue;
+                var classIndex = p * 1024 + i;
+                classes[classIndex] = entry;
             }
         }
         // add known classes which may not be in the table
@@ -2602,6 +2633,23 @@ ImageHeaderAudit.prototype.recordIssue = function(code, details) {
             entry.details = Object.assign({}, issueDetails, {
                 version: issueDetails.version || (this.match && this.match.version ? this.match.version : null),
             });
+            break;
+        case "class-table-page-missing":
+            entry.message = 'Image "' + this.imageName + '" references a missing class table page at index ' + issueDetails.pageIndex + '.';
+            entry.guidance = "Re-download the image or clear cached data before retrying in case the snapshot was truncated.";
+            entry.details = {
+                pageIndex: issueDetails.pageIndex,
+                pagePointer: issueDetails.pagePointer,
+            };
+            break;
+        case "class-table-entry-missing":
+            entry.message = 'Image "' + this.imageName + '" references a missing class definition at page ' + issueDetails.pageIndex + ', slot ' + issueDetails.entryIndex + '.';
+            entry.guidance = "This is usually caused by a corrupt or partial image download. Fetch a fresh copy of the image and try again.";
+            entry.details = {
+                pageIndex: issueDetails.pageIndex,
+                entryIndex: issueDetails.entryIndex,
+                entryPointer: issueDetails.entryPointer,
+            };
             break;
         default:
             entry.message = 'Image "' + this.imageName + '" encountered an unsupported header configuration.';


### PR DESCRIPTION
## Summary
- make Spur class table loading resilient to missing pages or entries and log audit issues instead of throwing
- provide dedicated audit messages for missing class table pages and entries
- add a unit test ensuring Spur class table loading tolerates a missing entry

## Testing
- node --test tests/unit/vm.image.class-table.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e449f54724832ab6ac7a2558f3b6c5